### PR TITLE
Chirp observational init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,140 @@
 .Rhistory
 .RData
 .Ruserdata
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Netcdf
+*.nc
+
+# VS code
+.vscode/

--- a/_targets.R
+++ b/_targets.R
@@ -26,9 +26,6 @@ options(clustermq.scheduler = "multicore")
 
 tar_source()
 
-
-
-
 list(
   tar_target(
     name = gdf_aoi_adm,

--- a/_targets.R
+++ b/_targets.R
@@ -32,10 +32,9 @@ tar_source()
 list(
   tar_target(
     name = gdf_aoi_adm,
-    command = load_proj_admins() %>% 
-      map(~.x %>% 
-            st_make_valid() %>% 
-            select(matches("^adm\\d_[ep]"))
-      )
+    command = load_proj_admins() %>%
+      map(~ .x %>%
+        st_make_valid() %>%
+        select(matches("^adm\\d_[ep]")))
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -1,0 +1,41 @@
+# Created by use_targets().
+# Follow the comments below to fill in this target script.
+# Then follow the manual to check and run the pipeline:
+#   https://books.ropensci.org/targets/walkthrough.html#inspect-the-pipeline
+
+# Load packages required to define the pipeline:
+library(targets)
+library(rnaturalearth)
+library(sf)
+library(tidyverse)
+library(rgee)
+library(janitor)
+library(rgee)
+library(tidyrgee)
+library(exactextractr)
+library(terra)
+library(tidync)
+
+# library(tarchetypes) # Load other packages as needed.
+
+# Set target options:
+tar_option_set(
+  packages = c("tibble") # packages that your targets need to run
+)
+options(clustermq.scheduler = "multicore")
+
+tar_source()
+
+
+
+
+list(
+  tar_target(
+    name = gdf_aoi_adm,
+    command = load_proj_admins() %>% 
+      map(~.x %>% 
+            st_make_valid() %>% 
+            select(matches("^adm\\d_[ep]"))
+      )
+  )
+)

--- a/_targets/.gitignore
+++ b/_targets/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!meta
+meta/*
+!meta/meta

--- a/_targets/meta/meta
+++ b/_targets/meta/meta
@@ -1,31 +1,14 @@
 name|type|data|command|depend|seed|path|time|size|bytes|format|repository|iteration|parent|children|seconds|warnings|error
-.Random.seed|object|b29cd8a0a951fbec|||||||||||||||
-aoi_bbox|stem|d5f1fa367527fe0a|2c1308c87c8e2304|b02fc3ed36aace23|-747169064||t19598.8334447375s|9824f8db58d58430|554|rds|local|vector|||0||
-aoi_countries|stem|29dc3b55db29efd8|1fdf2d8112e3228c|bfe9c24ca9136d8f|2029609669||t19598.8350352048s|cdbe451a6b064237|2805|rds|local|vector|||0.06|The returnclass argument of ne_download sp as of rnaturalearth 1.0.0.ℹ Please use sf objects with rnaturalearth, support for Spatial objects  sp will be removed in a future release of the package.|
-df_gtm_vhi_monthly_adm2|stem|ec067f96340bb99f|32937f8ff2e19d7d|0b0e4e083251da06|1391408404||t19613.7156173837s|c12e45ec068082f2|2563132|rds|local|vector|||12776.526||
-df_hn_ni_gt_vhi_monthly_adm2|stem||f4286cdc3454bd3f|1b1613f36424be4a|-667663768||t19610.9568624305s||0|rds|local|vector|||534.796||The eeFeatureCollection y must be not higher than 10 000.
-df_hn_vhi_monthly_adm2|stem||431fa485b58520b3|0b0e4e083251da06|1185238978||t19610.9667744612s||0|rds|local|vector|||1117.236|restarting interrupted promise evaluation|cnd is not a condition object.
-df_iri_adm0|stem|a5e222512fc22fa4|7dac976f330c7afb|ce9ecd14ae1f2305|796467628||t19625.9448829888s|998fe425e8f859d9|17252|rds|local|vector|||0.99||
-df_ni_vhi_monthly_adm2|stem||a2442ef48d7334c7|ed4f5abfbc3bd3cc|-2060868614||t19610.994818161s||0|rds|local|vector|||73.155||The eeFeatureCollection y must be not higher than 10 000.
-df_sum_cropland|stem|9674f8ab0cb9384c|66210b19975d9372|30c016eaf7b3216b|-651181735||t19625.7263659617s|001fa5a0c082fe27|364|rds|local|vector|||5.543|repeating attributes for all subgeometries for which they may not be constant. Expected 2 pieces. Missing pieces filled with NA in 4 rows 1, 2, 3, 4.|
-df_sv_vhi_monthly_adm2|stem|a647fba7d68f21cb|df071be89beef920|c254b05ff0aa0071|-1177730314||t19613.7562966579s|ee49e23739d4be08|1491251|rds|local|vector|||3514.395||
-df_vhi_monthly_adm2|stem||5943e45930efde12|a1518cf4c3520144|38956434||t19610.9857854366s||0|rds|local|vector|||13740.963|restarting interrupted promise evaluation|cnd is not a condition object.
-df_vhi_zonal_mean_adm0|stem|2f3ff134b6b2db18|70c8653b91963a50|9c30e02709cff8b9|1531032017||t19617.6516872295s|08fed25719250193|10393|rds|local|vector|||39.045|repeating attributes for all subgeometries for which they may not be constant|
-df_vhi_zonal_mean_adm2|stem|0059fce443968207|d22b7f24b7f35ac8|9c30e02709cff8b9|379758736||t19617.6587613129s|ec519ceac14e6e00|175|rds|local|vector|||32.549|repeating attributes for all subgeometries for which they may not be constant|
-dir_vhi_monthly|object|e134daa2019d12ba|||||||||||||||
+.Random.seed|object|8ff2b81cf6c6b9b5|||||||||||||||
+df_iri_adm0|stem|a5e222512fc22fa4|7dac976f330c7afb|ce9ecd14ae1f2305|796467628||t19626.7091366325s|998fe425e8f859d9|17252|rds|local|vector|||1.012||
 fp_iri_prob|object|be2208e64c26e452|||||||||||||||
-fp_r_fao_cropland|object|0fd58f3c9a87e8c8|||||||||||||||
-gdf_aoi_adm|stem|10cc8717e15fd508|b6f8c5e974fad3cb|dade321183e7dabe|1204730351||t19611.6173190763s|691cc41844a65629|66964017|rds|local|vector|||10.193||
+gdf_aoi_adm|stem|10cc8717e15fd508|b6f8c5e974fad3cb|dade321183e7dabe|1204730351||t19626.708586427s|691cc41844a65629|66964017|rds|local|vector|||11.067||
 iri_nc_to_r|function|f62c287298eefac9|||||||||||||||
-ldf_ni_vhi_monthly_adm2|stem|5f6edb7eabeb01b7|8485fad30e899db1|c4b9a38a0bb2f034|635978535||t19613.8594468062s|fe47e7a9ea4ab213|926955|rds|local|vector|||8912||
-ldf_sum_cropland_lte_vhi_threshold|stem|4f55cb618766d967|1f0fb76a023cce08|2ea4ed3634ccf170|2061212920||t19625.7133877156s|a9ee31395401f82e|257185|rds|local|vector|||858.817|repeating attributes for all subgeometries for which they may not be constant|
-ldf_vhi_threshold_testing_pct_gte_adm0|stem|cc83cb244774eedc|e149a18c46adf82c|45f9bf95024001a4|1795990606||t19616.6653248646s||250120|rds|local|vector|||36.347|repeating attributes for all subgeometries for which they may not be constant|too many arguments
 load_proj_admins|function|09d2fd9d45a754a8|||||||||||||||
 pct_cropland_lte_vhi_thresh|function|79274c76cf4797f1|||||||||||||||
 vhi_mo_composite_reduce_region|function|5ae004a1eca97058|||||||||||||||
 vhi_mo_composite_reduce_region_batch|function|10fe3a09971aba92|||||||||||||||
 vhi_year_month_composites|function|ca8ce0860544d5bf|||||||||||||||
 vhi_zonal|function|524bd441e5290fb5|||||||||||||||
-vhi_zonal_mean|function|a7560a2c32969891|||||||||||||||
 vhi_zonal_pct_lte_thresh|function|0972ca9c5de9a5a4|||||||||||||||
 zonal_sum_cropland|function|f6cb2a92e96f7434|||||||||||||||

--- a/_targets/meta/meta
+++ b/_targets/meta/meta
@@ -1,0 +1,31 @@
+name|type|data|command|depend|seed|path|time|size|bytes|format|repository|iteration|parent|children|seconds|warnings|error
+.Random.seed|object|b29cd8a0a951fbec|||||||||||||||
+aoi_bbox|stem|d5f1fa367527fe0a|2c1308c87c8e2304|b02fc3ed36aace23|-747169064||t19598.8334447375s|9824f8db58d58430|554|rds|local|vector|||0||
+aoi_countries|stem|29dc3b55db29efd8|1fdf2d8112e3228c|bfe9c24ca9136d8f|2029609669||t19598.8350352048s|cdbe451a6b064237|2805|rds|local|vector|||0.06|The returnclass argument of ne_download sp as of rnaturalearth 1.0.0.ℹ Please use sf objects with rnaturalearth, support for Spatial objects  sp will be removed in a future release of the package.|
+df_gtm_vhi_monthly_adm2|stem|ec067f96340bb99f|32937f8ff2e19d7d|0b0e4e083251da06|1391408404||t19613.7156173837s|c12e45ec068082f2|2563132|rds|local|vector|||12776.526||
+df_hn_ni_gt_vhi_monthly_adm2|stem||f4286cdc3454bd3f|1b1613f36424be4a|-667663768||t19610.9568624305s||0|rds|local|vector|||534.796||The eeFeatureCollection y must be not higher than 10 000.
+df_hn_vhi_monthly_adm2|stem||431fa485b58520b3|0b0e4e083251da06|1185238978||t19610.9667744612s||0|rds|local|vector|||1117.236|restarting interrupted promise evaluation|cnd is not a condition object.
+df_iri_adm0|stem|a5e222512fc22fa4|7dac976f330c7afb|ce9ecd14ae1f2305|796467628||t19625.9448829888s|998fe425e8f859d9|17252|rds|local|vector|||0.99||
+df_ni_vhi_monthly_adm2|stem||a2442ef48d7334c7|ed4f5abfbc3bd3cc|-2060868614||t19610.994818161s||0|rds|local|vector|||73.155||The eeFeatureCollection y must be not higher than 10 000.
+df_sum_cropland|stem|9674f8ab0cb9384c|66210b19975d9372|30c016eaf7b3216b|-651181735||t19625.7263659617s|001fa5a0c082fe27|364|rds|local|vector|||5.543|repeating attributes for all subgeometries for which they may not be constant. Expected 2 pieces. Missing pieces filled with NA in 4 rows 1, 2, 3, 4.|
+df_sv_vhi_monthly_adm2|stem|a647fba7d68f21cb|df071be89beef920|c254b05ff0aa0071|-1177730314||t19613.7562966579s|ee49e23739d4be08|1491251|rds|local|vector|||3514.395||
+df_vhi_monthly_adm2|stem||5943e45930efde12|a1518cf4c3520144|38956434||t19610.9857854366s||0|rds|local|vector|||13740.963|restarting interrupted promise evaluation|cnd is not a condition object.
+df_vhi_zonal_mean_adm0|stem|2f3ff134b6b2db18|70c8653b91963a50|9c30e02709cff8b9|1531032017||t19617.6516872295s|08fed25719250193|10393|rds|local|vector|||39.045|repeating attributes for all subgeometries for which they may not be constant|
+df_vhi_zonal_mean_adm2|stem|0059fce443968207|d22b7f24b7f35ac8|9c30e02709cff8b9|379758736||t19617.6587613129s|ec519ceac14e6e00|175|rds|local|vector|||32.549|repeating attributes for all subgeometries for which they may not be constant|
+dir_vhi_monthly|object|e134daa2019d12ba|||||||||||||||
+fp_iri_prob|object|be2208e64c26e452|||||||||||||||
+fp_r_fao_cropland|object|0fd58f3c9a87e8c8|||||||||||||||
+gdf_aoi_adm|stem|10cc8717e15fd508|b6f8c5e974fad3cb|dade321183e7dabe|1204730351||t19611.6173190763s|691cc41844a65629|66964017|rds|local|vector|||10.193||
+iri_nc_to_r|function|f62c287298eefac9|||||||||||||||
+ldf_ni_vhi_monthly_adm2|stem|5f6edb7eabeb01b7|8485fad30e899db1|c4b9a38a0bb2f034|635978535||t19613.8594468062s|fe47e7a9ea4ab213|926955|rds|local|vector|||8912||
+ldf_sum_cropland_lte_vhi_threshold|stem|4f55cb618766d967|1f0fb76a023cce08|2ea4ed3634ccf170|2061212920||t19625.7133877156s|a9ee31395401f82e|257185|rds|local|vector|||858.817|repeating attributes for all subgeometries for which they may not be constant|
+ldf_vhi_threshold_testing_pct_gte_adm0|stem|cc83cb244774eedc|e149a18c46adf82c|45f9bf95024001a4|1795990606||t19616.6653248646s||250120|rds|local|vector|||36.347|repeating attributes for all subgeometries for which they may not be constant|too many arguments
+load_proj_admins|function|09d2fd9d45a754a8|||||||||||||||
+pct_cropland_lte_vhi_thresh|function|79274c76cf4797f1|||||||||||||||
+vhi_mo_composite_reduce_region|function|5ae004a1eca97058|||||||||||||||
+vhi_mo_composite_reduce_region_batch|function|10fe3a09971aba92|||||||||||||||
+vhi_year_month_composites|function|ca8ce0860544d5bf|||||||||||||||
+vhi_zonal|function|524bd441e5290fb5|||||||||||||||
+vhi_zonal_mean|function|a7560a2c32969891|||||||||||||||
+vhi_zonal_pct_lte_thresh|function|0972ca9c5de9a5a4|||||||||||||||
+zonal_sum_cropland|function|f6cb2a92e96f7434|||||||||||||||

--- a/data-raw/chirps_adm0_monthly.R
+++ b/data-raw/chirps_adm0_monthly.R
@@ -1,0 +1,63 @@
+# Download monthly historical CHIRPS precipitation from GEE
+# you will need a GEE account and `{rgee}` set up (https://github.com/r-spatial/rgee)
+
+# script meant to be run as a background process through terminal
+# i.e on mac I do `caffeinate -s Rscript data-raw/chirps_adm0_monthly.R`
+# You may want to run `ee_Initialize()` out of background processing if you face an authentication error
+
+
+library(rgee)
+library(tidyverse)
+library(tidyrgee)
+library(targets)
+ee_Initialize()
+tar_load(gdf_aoi_adm)
+
+out_dir <- file.path(
+  Sys.getenv("AA_DATA_DIR"),
+  "public",
+  "processed",
+  "lac"
+) 
+
+
+cat("reading and manipulate image collection\n")
+ic <- ee$ImageCollection("UCSB-CHG/CHIRPS/DAILY")
+tic <- as_tidyee(ic)
+
+tic_monthly_rainfall <- tic %>% 
+  group_by(year,month) %>% 
+  summarise(
+    stat= "sum"
+  )
+
+cat("get adm0 boundaries from FAO\n")
+fc_adm0 = ee$FeatureCollection('FAO/GAUL/2015/level0')
+
+fc_region_adm0 <- fc_adm0$filter(ee$Filter$inList("ADM0_NAME",  c("Guatemala",
+                                                                  "Nicaragua",
+                                                                  "Honduras",
+                                                                  "El Salvador"))
+)
+
+cat("begin extraction of zonal stats\n")
+df_rainfall_adm0 <- ee_extract_tidy(x = tic_monthly_rainfall,
+                y = fc_region_adm0,
+                scale = 5566,
+                stat = "mean",
+                via = "drive")
+
+
+cat("write zonal sats to csv\n")
+write_csv(x = df_rainfall_adm0,
+          file = file.path(
+            out_dir,
+            "chirps_monthly_adm0.csv"
+          )
+)
+cat("finished")
+
+
+
+
+

--- a/exploration/CHIRPS_Observational_Explore.Rmd
+++ b/exploration/CHIRPS_Observational_Explore.Rmd
@@ -1,0 +1,211 @@
+---
+title: "CHIRPS Observational"
+output: html_document
+date: "2023-09-22"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+## Intro
+
+This document plots historical monthly rainfall (CHIRPS) for the  4 countries (Guatemala , Nicaragua, El Salvador, Hondura) in the Central American Dry Corridor (CACD). This initial work was not done with the exact framework in-mind, but rather to get a sense of current situation.
+
+
+```{r setInputs}
+
+# first load in data
+library(tidyverse)
+library(gghdx)
+library(glue)
+gghdx()
+
+
+df_chirps <- read_csv(file.path(
+  Sys.getenv("AA_DATA_DIR"),
+  "public",
+  "processed",
+  "lac",
+  "chirps_monthly_adm0.csv"
+) 
+)
+
+# El Nino year - Just from Wikipedia for a first glance
+df_el_nino_years <- tibble(
+  date = 
+    c("1982-1983",
+      "1997-1998",
+      "2002-2003",
+      "2004-2005",
+      "2006-2007",
+      "2009-2010",
+      "2014-2016",
+      "2018-2019",
+      "2023-2024"
+    )
+) %>% 
+  separate(
+    date ,into = c("start_date","end_date"),sep = "-"
+  ) 
+
+# fomat data.frame for ggplot
+df_el_nino_years <- df_el_nino_years %>% 
+  mutate(
+    start_date= glue("{start_date}-01-01") %>% as_date(),
+    end_date = glue("{end_date}-12-31") %>% as_date()
+  )
+```
+
+
+# Jan-August cumulative historical rainfall
+
+```{r plotJFMAMJJA}
+
+df_to_august <- df_chirps %>% 
+  mutate(
+    cat = case_when(
+      month(date) %in% c(1:8)~ "up_to_current",
+      .default =NA
+    )
+  ) %>% 
+  filter(!is.na(cat)) %>% 
+  group_by(ADM0_NAME,date=floor_date(date,"year")) %>% 
+  summarise(
+    rainfall_mm = sum(value)
+  ) 
+
+
+df_to_august_top5_dry <- df_to_august %>% 
+  group_by(ADM0_NAME) %>% 
+  slice_min(order_by = rainfall_mm,n = 5) %>% 
+  ungroup() %>% 
+  mutate(
+    adm0_date = paste0(ADM0_NAME,"_",date)
+  )
+
+df_august_2023 <- df_to_august %>% 
+  filter(year(date)==2023)
+
+df_to_august %>% 
+  mutate(
+    adm0_date = paste0(ADM0_NAME,"_",date),
+    pt_color = adm0_date %in% df_to_august_top5_dry$adm0_date,
+    pt_label = ifelse(adm0_date %in% df_to_august_top5_dry$adm0_date,year(date),NA)
+  ) %>% 
+  ggplot()+
+  geom_rect(
+    data= df_el_nino_years,
+    aes(
+      xmin = start_date,
+      xmax = end_date,
+      ymin = -Inf,
+      ymax = Inf
+    ),
+    alpha = 0.2,
+    fill = hdx_hex("tomato-hdx")
+  )+
+  geom_point(aes(x=date, y= rainfall_mm,color=pt_color))+
+  geom_text(aes(x=date, y=rainfall_mm,label=pt_label),nudge_y = 40)+
+  
+  geom_hline(
+    data= df_august_2023,
+    aes(yintercept=rainfall_mm),
+    linetype="dashed",
+    color=hdx_hex("tomato-hdx")
+  )+
+  facet_wrap(~ADM0_NAME)+
+  scale_x_date(date_breaks = "2 year",date_labels = "%Y",
+               limits = as.Date(c("1981-01-01", "2024-12-31")),
+               expand = c(0,0)
+               # expand = c(as_date("1981-01-01"), as_date("2023-01-01"))
+  )+
+  scale_y_reverse_hdx()+
+  labs(
+    y = "Rainfall Total (mm)",
+    title = "Total January-August Rainfall by Year (CHIRPS)",
+    subtitle = "Vertical red bars indicate el nino years, horizontal dashed line are 2023 values")+
+  theme(
+    axis.text.x = element_text(angle= 90),
+    legend.position = 'none',
+    axis.title.x = element_blank(),
+    panel.border = element_rect(color="grey", fill=NA)
+    
+  )
+```
+
+
+# June-July-August cumulative historical rainfall
+
+```{r plotJJA}
+df_jja <- df_chirps %>% 
+  mutate(
+    cat = case_when(
+      month(date) %in% c(6:8)~ "JJA",
+      .default =NA
+    )
+  ) %>% 
+  filter(!is.na(cat)) %>% 
+  group_by(ADM0_NAME,date=floor_date(date,"year")) %>% 
+  summarise(
+    rainfall_mm = sum(value),
+    .groups = "drop"
+  ) 
+df_jja_top5_dry <- df_jja %>% 
+  group_by(ADM0_NAME) %>% 
+  slice_min(order_by = rainfall_mm,n = 5) %>% 
+  ungroup() %>% 
+  mutate(
+    adm0_date = paste0(ADM0_NAME,"_",date)
+  )
+
+df_jja2023<- df_jja %>% 
+  filter(year(date)==2023)
+
+df_jja %>% 
+  mutate(
+    adm0_date = paste0(ADM0_NAME,"_",date),
+    pt_color = adm0_date %in% df_jja_top5_dry$adm0_date,
+    pt_label = ifelse(adm0_date %in% df_jja_top5_dry$adm0_date,year(date),NA)
+  ) %>% 
+  ggplot()+
+  geom_rect(
+    data= df_el_nino_years,
+    aes(
+      xmin = start_date,
+      xmax = end_date,
+      ymin = -Inf,
+      ymax = Inf
+    ),
+    alpha = 0.2,
+    fill = hdx_hex("tomato-hdx")
+  )+
+  geom_point(aes(x=date, y= rainfall_mm,color=pt_color))+
+  geom_text(aes(x=date, y=rainfall_mm,label=pt_label),nudge_y = 40)+
+
+  geom_hline(
+    data= df_jja2023,aes(yintercept=rainfall_mm),
+    linetype="dashed",
+    color=hdx_hex("tomato-hdx")
+             )+
+  facet_wrap(~ADM0_NAME)+
+  scale_x_date(date_breaks = "2 year",date_labels = "%Y",
+               limits = as.Date(c("1981-01-01", "2024-12-31")),
+               expand = c(0,0)
+               # expand = c(as_date("1981-01-01"), as_date("2023-01-01"))
+               )+
+  scale_y_reverse_hdx()+
+  labs(
+    y = "Rainfall Total (mm)",
+    title = "Total JJA Rainfall by Year (CHIRPS)",
+       subtitle = "Vertical red bars indicate el nino years, horizontal dashed line are 2023 values")+
+  theme(
+    axis.text.x = element_text(angle= 90),
+    legend.position = 'none',
+    axis.title.x = element_blank(),
+    panel.border = element_rect(color="grey", fill=NA)
+    
+  )
+
+```
+

--- a/exploration/CHIRPS_Observational_Explore.Rmd
+++ b/exploration/CHIRPS_Observational_Explore.Rmd
@@ -14,7 +14,6 @@ This document plots historical monthly rainfall (CHIRPS) for the  4 countries (G
 
 
 ```{r setInputs}
-
 # first load in data
 library(tidyverse)
 library(gghdx)
@@ -28,13 +27,13 @@ df_chirps <- read_csv(file.path(
   "processed",
   "lac",
   "chirps_monthly_adm0.csv"
-) 
-)
+))
 
 # El Nino year - Just from Wikipedia for a first glance
 df_el_nino_years <- tibble(
-  date = 
-    c("1982-1983",
+  date =
+    c(
+      "1982-1983",
       "1997-1998",
       "2002-2003",
       "2004-2005",
@@ -44,15 +43,16 @@ df_el_nino_years <- tibble(
       "2018-2019",
       "2023-2024"
     )
-) %>% 
+) %>%
   separate(
-    date ,into = c("start_date","end_date"),sep = "-"
-  ) 
+    date,
+    into = c("start_date", "end_date"), sep = "-"
+  )
 
 # fomat data.frame for ggplot
-df_el_nino_years <- df_el_nino_years %>% 
+df_el_nino_years <- df_el_nino_years %>%
   mutate(
-    start_date= glue("{start_date}-01-01") %>% as_date(),
+    start_date = glue("{start_date}-01-01") %>% as_date(),
     end_date = glue("{end_date}-12-31") %>% as_date()
   )
 ```
@@ -61,41 +61,40 @@ df_el_nino_years <- df_el_nino_years %>%
 # Jan-August cumulative historical rainfall
 
 ```{r plotJFMAMJJA}
-
-df_to_august <- df_chirps %>% 
+df_to_august <- df_chirps %>%
   mutate(
     cat = case_when(
-      month(date) %in% c(1:8)~ "up_to_current",
-      .default =NA
+      month(date) %in% c(1:8) ~ "up_to_current",
+      .default = NA
     )
-  ) %>% 
-  filter(!is.na(cat)) %>% 
-  group_by(ADM0_NAME,date=floor_date(date,"year")) %>% 
+  ) %>%
+  filter(!is.na(cat)) %>%
+  group_by(ADM0_NAME, date = floor_date(date, "year")) %>%
   summarise(
     rainfall_mm = sum(value)
-  ) 
-
-
-df_to_august_top5_dry <- df_to_august %>% 
-  group_by(ADM0_NAME) %>% 
-  slice_min(order_by = rainfall_mm,n = 5) %>% 
-  ungroup() %>% 
-  mutate(
-    adm0_date = paste0(ADM0_NAME,"_",date)
   )
 
-df_august_2023 <- df_to_august %>% 
-  filter(year(date)==2023)
 
-df_to_august %>% 
+df_to_august_top5_dry <- df_to_august %>%
+  group_by(ADM0_NAME) %>%
+  slice_min(order_by = rainfall_mm, n = 5) %>%
+  ungroup() %>%
   mutate(
-    adm0_date = paste0(ADM0_NAME,"_",date),
+    adm0_date = paste0(ADM0_NAME, "_", date)
+  )
+
+df_august_2023 <- df_to_august %>%
+  filter(year(date) == 2023)
+
+df_to_august %>%
+  mutate(
+    adm0_date = paste0(ADM0_NAME, "_", date),
     pt_color = adm0_date %in% df_to_august_top5_dry$adm0_date,
-    pt_label = ifelse(adm0_date %in% df_to_august_top5_dry$adm0_date,year(date),NA)
-  ) %>% 
-  ggplot()+
+    pt_label = ifelse(adm0_date %in% df_to_august_top5_dry$adm0_date, year(date), NA)
+  ) %>%
+  ggplot() +
   geom_rect(
-    data= df_el_nino_years,
+    data = df_el_nino_years,
     aes(
       xmin = start_date,
       xmax = end_date,
@@ -104,33 +103,33 @@ df_to_august %>%
     ),
     alpha = 0.2,
     fill = hdx_hex("tomato-hdx")
-  )+
-  geom_point(aes(x=date, y= rainfall_mm,color=pt_color))+
-  geom_text(aes(x=date, y=rainfall_mm,label=pt_label),nudge_y = 40)+
-  
+  ) +
+  geom_point(aes(x = date, y = rainfall_mm, color = pt_color)) +
+  geom_text(aes(x = date, y = rainfall_mm, label = pt_label), nudge_y = 40) +
   geom_hline(
-    data= df_august_2023,
-    aes(yintercept=rainfall_mm),
-    linetype="dashed",
-    color=hdx_hex("tomato-hdx")
-  )+
-  facet_wrap(~ADM0_NAME)+
-  scale_x_date(date_breaks = "2 year",date_labels = "%Y",
-               limits = as.Date(c("1981-01-01", "2024-12-31")),
-               expand = c(0,0)
-               # expand = c(as_date("1981-01-01"), as_date("2023-01-01"))
-  )+
-  scale_y_reverse_hdx()+
+    data = df_august_2023,
+    aes(yintercept = rainfall_mm),
+    linetype = "dashed",
+    color = hdx_hex("tomato-hdx")
+  ) +
+  facet_wrap(~ADM0_NAME) +
+  scale_x_date(
+    date_breaks = "2 year", date_labels = "%Y",
+    limits = as.Date(c("1981-01-01", "2024-12-31")),
+    expand = c(0, 0)
+    # expand = c(as_date("1981-01-01"), as_date("2023-01-01"))
+  ) +
+  scale_y_reverse_hdx() +
   labs(
     y = "Rainfall Total (mm)",
     title = "Total January-August Rainfall by Year (CHIRPS)",
-    subtitle = "Vertical red bars indicate el nino years, horizontal dashed line are 2023 values")+
+    subtitle = "Vertical red bars indicate el nino years, horizontal dashed line are 2023 values"
+  ) +
   theme(
-    axis.text.x = element_text(angle= 90),
-    legend.position = 'none',
+    axis.text.x = element_text(angle = 90),
+    legend.position = "none",
     axis.title.x = element_blank(),
-    panel.border = element_rect(color="grey", fill=NA)
-    
+    panel.border = element_rect(color = "grey", fill = NA)
   )
 ```
 
@@ -138,39 +137,39 @@ df_to_august %>%
 # June-July-August cumulative historical rainfall
 
 ```{r plotJJA}
-df_jja <- df_chirps %>% 
+df_jja <- df_chirps %>%
   mutate(
     cat = case_when(
-      month(date) %in% c(6:8)~ "JJA",
-      .default =NA
+      month(date) %in% c(6:8) ~ "JJA",
+      .default = NA
     )
-  ) %>% 
-  filter(!is.na(cat)) %>% 
-  group_by(ADM0_NAME,date=floor_date(date,"year")) %>% 
+  ) %>%
+  filter(!is.na(cat)) %>%
+  group_by(ADM0_NAME, date = floor_date(date, "year")) %>%
   summarise(
     rainfall_mm = sum(value),
     .groups = "drop"
-  ) 
-df_jja_top5_dry <- df_jja %>% 
-  group_by(ADM0_NAME) %>% 
-  slice_min(order_by = rainfall_mm,n = 5) %>% 
-  ungroup() %>% 
+  )
+df_jja_top5_dry <- df_jja %>%
+  group_by(ADM0_NAME) %>%
+  slice_min(order_by = rainfall_mm, n = 5) %>%
+  ungroup() %>%
   mutate(
-    adm0_date = paste0(ADM0_NAME,"_",date)
+    adm0_date = paste0(ADM0_NAME, "_", date)
   )
 
-df_jja2023<- df_jja %>% 
-  filter(year(date)==2023)
+df_jja2023 <- df_jja %>%
+  filter(year(date) == 2023)
 
-df_jja %>% 
+df_jja %>%
   mutate(
-    adm0_date = paste0(ADM0_NAME,"_",date),
+    adm0_date = paste0(ADM0_NAME, "_", date),
     pt_color = adm0_date %in% df_jja_top5_dry$adm0_date,
-    pt_label = ifelse(adm0_date %in% df_jja_top5_dry$adm0_date,year(date),NA)
-  ) %>% 
-  ggplot()+
+    pt_label = ifelse(adm0_date %in% df_jja_top5_dry$adm0_date, year(date), NA)
+  ) %>%
+  ggplot() +
   geom_rect(
-    data= df_el_nino_years,
+    data = df_el_nino_years,
     aes(
       xmin = start_date,
       xmax = end_date,
@@ -179,33 +178,32 @@ df_jja %>%
     ),
     alpha = 0.2,
     fill = hdx_hex("tomato-hdx")
-  )+
-  geom_point(aes(x=date, y= rainfall_mm,color=pt_color))+
-  geom_text(aes(x=date, y=rainfall_mm,label=pt_label),nudge_y = 40)+
-
+  ) +
+  geom_point(aes(x = date, y = rainfall_mm, color = pt_color)) +
+  geom_text(aes(x = date, y = rainfall_mm, label = pt_label), nudge_y = 40) +
   geom_hline(
-    data= df_jja2023,aes(yintercept=rainfall_mm),
-    linetype="dashed",
-    color=hdx_hex("tomato-hdx")
-             )+
-  facet_wrap(~ADM0_NAME)+
-  scale_x_date(date_breaks = "2 year",date_labels = "%Y",
-               limits = as.Date(c("1981-01-01", "2024-12-31")),
-               expand = c(0,0)
-               # expand = c(as_date("1981-01-01"), as_date("2023-01-01"))
-               )+
-  scale_y_reverse_hdx()+
+    data = df_jja2023, aes(yintercept = rainfall_mm),
+    linetype = "dashed",
+    color = hdx_hex("tomato-hdx")
+  ) +
+  facet_wrap(~ADM0_NAME) +
+  scale_x_date(
+    date_breaks = "2 year", date_labels = "%Y",
+    limits = as.Date(c("1981-01-01", "2024-12-31")),
+    expand = c(0, 0)
+    # expand = c(as_date("1981-01-01"), as_date("2023-01-01"))
+  ) +
+  scale_y_reverse_hdx() +
   labs(
     y = "Rainfall Total (mm)",
     title = "Total JJA Rainfall by Year (CHIRPS)",
-       subtitle = "Vertical red bars indicate el nino years, horizontal dashed line are 2023 values")+
+    subtitle = "Vertical red bars indicate el nino years, horizontal dashed line are 2023 values"
+  ) +
   theme(
-    axis.text.x = element_text(angle= 90),
-    legend.position = 'none',
+    axis.text.x = element_text(angle = 90),
+    legend.position = "none",
     axis.title.x = element_blank(),
-    panel.border = element_rect(color="grey", fill=NA)
-    
+    panel.border = element_rect(color = "grey", fill = NA)
   )
-
 ```
 


### PR DESCRIPTION
light analysis of chirps monthly data

- CHIRPS daily data processed to monthly zonal stats [chirps_adm0_monthly](https://github.com/OCHA-DAP/ds-aa-lac-dry-corridor/blob/chirp-observational-init/data-raw/chirps_adm0_monthly.R). 
- 1 [Rmd notebook](https://github.com/OCHA-DAP/ds-aa-lac-dry-corridor/blob/chirp-observational-init/exploration/CHIRPS_Observational_Explore.Rmd) made to create 2 plots for initial request for information from CERF
- initiated `_targets.R` just to make the admin layers more readily available + I am using the targets in upstream branches for computationally heavier steps

You can just load the data directly in the notebook and checkout the graphs if you don't feel like setting up `{rgee}` and earth engine to do this PR review.
