### PR TITLE
download ECMWF SEAS51 data

### DIFF
--- a/data-raw/ecmwf_seas51.R
+++ b/data-raw/ecmwf_seas51.R
@@ -1,0 +1,115 @@
+#' Download ECMWF SEAS51 Data for the AOI (Nicaragua, Honduras, Guatemala, El Salvador)
+#' Uses [ecmwfr package](https://github.com/bluegreen-labs/ecmwfr) package to access [ECMWF Climate Data Store API ](https://cds.climate.copernicus.eu/)
+#' Registration instructions are available in teh above ecmwfr package link.
+
+library(ecmwfr)
+library(tidyverse)
+library(sf)
+library(rnaturalearth)
+library(glue)
+
+
+fp_outpath_ecmwf <- file.path(
+  Sys.getenv("AA_DATA_DIR"),
+  "private",
+  "raw",
+  "lac",
+  "ecmwf_seasonal",
+  "seas51"
+  
+)
+# think only need to do this 1x
+ecmwfr::wf_set_key(
+  user=Sys.getenv("ECMWF_USER_UID"),
+  key = Sys.getenv("ECMWF_USER_KEY"),
+  service = "cds"
+)
+
+
+df_cds_datasets<- wf_datasets(
+  user=Sys.getenv("ECMWF_USER_UID"),
+  service = "cds"
+)
+df_cds_datasets %>% 
+  tibble() %>% 
+  filter(
+    str_detect(name, "seas")
+  )
+prod_info <- wf_product_info(
+  dataset = "seasonal-monthly-single-levels",
+  user=Sys.getenv("ECMWF_USER_UID"),
+  service = "cds"
+)
+
+cat("printing layers\n")
+str_extract_all(prod_info$rich_abstract,pattern = "<td class='variables-name'>(.*?)</td>")
+
+
+cat("defining bbox for extraction\n")
+aoi_countries <- ne_countries(country = c("Nicaragua","Honduras","Guatemala","El Salvador")) %>% 
+  st_as_sf() %>% 
+  select(
+    contains("admin"),
+    iso_a3
+  )
+aoi_bbox <- st_bbox(aoi_countries) 
+
+
+cat("writing data requests to list\n")
+request_coords<- glue("{aoi_bbox['ymin']}/{aoi_bbox['xmin']}/{aoi_bbox['ymax']}/{aoi_bbox['xmax']}")
+
+
+request_lte_2022 <- c(1:4) %>% 
+  map(
+    ~list(
+      product_type = "monthly_mean",
+      format = "netcdf",
+      originating_centre = "ecmwf",
+      system="51",
+      variable = c("total_precipitation"),
+      year = as.character(c(1981:2022)),
+      month = sprintf("%02d",c(1:12)),
+      area = request_coords,
+      leadtime_month = .x,
+      dataset_short_name = "seasonal-monthly-single-levels",
+      target = glue("ecmwf_forecast_lte2022_lt{.x}.nc")
+    )
+  )
+
+request_2023 <- c(1:4) %>% 
+  map(
+    ~list(
+      product_type = "monthly_mean",
+      format = "netcdf",
+      originating_centre = "ecmwf",
+      system ="51",
+      variable = c("total_precipitation"),
+      year = as.character(c(2023)),
+      month = sprintf("%02d",c(1:9)),
+      area = request_coords,
+      leadtime_month = .x,
+      dataset_short_name = "seasonal-monthly-single-levels",
+      target = glue("ecmwf_forecast_2023_lt{.x}.nc")
+    )
+  )
+
+cat("Downloading 2023 data\n")
+request_2023 %>% 
+  map(\(rq){
+    wf_request(user     = Sys.getenv("ECMWF_USER_UID"),  # user ID (for authentication)
+               request  = rq,  # the request
+               transfer = TRUE,   # download the file
+               path = fp_outpath_ecmwf)}
+    )
+cat("2023 data Jan - September downloaded to AA_DATA_DIR")
+
+cat("Downloading data 1981-2022\n")
+request_lte_2022 %>% 
+  map(\(rq){
+    wf_request(user     = Sys.getenv("ECMWF_USER_UID"),  # user ID (for authentication)
+               request  = rq,  # the request
+               transfer = TRUE,   # download the file
+               path = fp_outpath_ecmwf)}
+  )
+
+cat('1981-2022 data Jan - December downloaded to AA_DATA_DIR')

--- a/exploration/05_ECMWF_seasonal_explore.Rmd
+++ b/exploration/05_ECMWF_seasonal_explore.Rmd
@@ -1,0 +1,412 @@
+---
+title: "ECMWF Data - Preliminary Look"
+output: html_document
+date: "2023-09-20"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+## Intro
+
+- The aim of this document is a quick exploration of ECMWF Seasonal Forecast data. The data was downloaded with  `data-raw/ecmwf_seas51.R` using the `{ecmwfr}` package.
+
+- Currently awaiting inputs from partners regarding the preferred data sources. Therefore, this document is a preliminary look at the data without a very clear objective rather than familiarization. 
+
+- There is an ongoing larger discussion regarding converting monthly forecast values to data to trimester tercile probability values. This is out of the scope of this document.
+
+**NOTE:** IMO - no need for code review at te moment
+
+```{r cars}
+library(tidyverse)
+library(tidync)
+library(rhdx)
+library(sf)
+library(rnaturalearth)
+library(ncdf4)
+library(terra)
+library(exactextractr)
+library(targets)
+library(glue)
+gghdx()
+
+tar_load(gdf_aoi_adm)
+
+
+fp_seas51 <- file.path(
+  Sys.getenv("AA_DATA_DIR"),
+  "private",
+  "raw",
+  "lac",
+  "ecmwf_seasonal",
+  "seas51"
+)
+
+# lets simplify admin 1 - remove slivers/islands
+adm0_main <- gdf_aoi_adm$adm0 %>%
+  st_cast("POLYGON") %>%
+  mutate(
+    area = as.numeric(st_area(.))
+  ) %>%
+  filter(
+    area > 1e10
+  )
+
+poly_simp_adm0 <- adm0_main %>%
+  group_by(adm0_es) %>%
+  summarise() %>%
+  st_simplify(dTolerance = 0.01)
+
+
+
+fnames <- dir(fp_seas51)
+
+# list of rasters
+lr <- fnames %>%
+  map(
+    \(fname){
+      fp <- file.path(fp_seas51, fname)
+      nf <- nc_open(fp)
+
+      # get precipitation rate
+      # it's 4D for each value there is 1. lat, 2. lon, 3. ensemble, 4. time)
+      tprate_array <- ncvar_get(nf, "tprate")
+
+      # get fill value
+      fill_value <- ncatt_get(nf, "tprate", "_FillValue")
+
+      # fill array w/ standard NA
+      tprate_array[tprate_array == fill_value$value] <- NA
+      tprate_mean_array <- apply(tprate_array, c(1, 2, 4), mean, na.rm = T)
+
+
+      lon <- ncvar_get(nf, "longitude")
+      lat <- ncvar_get(nf, "latitude", verbose = F)
+      t_hours <- ncvar_get(nf, "time")
+
+      r <- rast(
+        x = aperm(tprate_mean_array, c(2, 1, 3)),
+        extent = ext(
+          min(lon) - .5,
+          max(lon) + .5,
+          min(lat) - .5,
+          max(lat) + 0.5
+        ),
+        crs = "EPSG:4326"
+      )
+      dates_predicted <- as_date(as_date("1900-01-01") + hours(t_hours))
+      set.names(r, dates_predicted)
+      return(r)
+    }
+  ) %>%
+  set_names(fnames)
+```
+
+
+```{r}
+# run zonal stats at regional level (all 4 countries)
+
+# list rasters historical
+lr_historical <- lr %>%
+  keep_at(~ str_detect(.x, "2022"))
+
+# list rasters latest
+lr_latest <- lr %>%
+  keep_at(~ str_detect(.x, "2023"))
+
+
+
+df_zonal_historical_regional <- map2_dfr(
+  lr_historical,
+  c(lt = 1, lt = 2, lt = 3, lt = 4),
+  \(rtmp, lt){
+    exact_extract(
+      x = rtmp,
+      y = poly_simp_adm0 %>%
+        summarise(),
+      fun = "mean"
+    ) %>%
+      pivot_longer(everything()) %>%
+      separate(name, into = c("stat", "date"), sep = "\\.") %>%
+      pivot_wider(names_from = "stat", values_from = "value") %>%
+      mutate(
+        date = as_date(date),
+        leadtime = lt
+      )
+  }
+)
+
+df_zonal_latest_regional <- map2_dfr(
+  lr_latest,
+  c(lt = 1, lt = 2, lt = 3, lt = 4),
+  \(rtmp, lt){
+    exact_extract(
+      x = rtmp,
+      y = poly_simp_adm0 %>%
+        summarise(),
+      fun = "mean"
+    ) %>%
+      pivot_longer(everything()) %>%
+      separate(name, into = c("stat", "date"), sep = "\\.") %>%
+      pivot_wider(names_from = "stat", values_from = "value") %>%
+      mutate(
+        date = as_date(date),
+        leadtime = lt
+      )
+  }
+)
+
+df_zonal_regional <- bind_rows(
+  df_zonal_historical_regional,
+  df_zonal_latest_regional,
+) %>%
+  mutate(
+    # units are m/s - convert to meters: 60 s * 60 minutes * 24 hours * 30 days
+    # meters to mm = m * 1000
+    total_mean_mm = (mean * (60 * 60 * 24 * 30)) * 1000
+  )
+```
+
+
+```{r}
+df_zonal_historical_adm0 <- map2_dfr(
+  lr_historical,
+  c(lt = 1, lt = 2, lt = 3, lt = 4),
+  \(rtmp, lt){
+    exact_extract(
+      x = rtmp,
+      y = poly_simp_adm0,
+      fun = "mean",
+      append_cols = "adm0_es"
+    ) %>%
+      pivot_longer(-matches("adm0_es")) %>%
+      separate(name, into = c("stat", "date"), sep = "\\.") %>%
+      pivot_wider(names_from = "stat", values_from = "value") %>%
+      mutate(
+        date = as_date(date),
+        leadtime = lt
+      )
+  }
+)
+
+df_zonal_latest_adm0 <- map2_dfr(
+  lr_latest,
+  c(lt = 1, lt = 2, lt = 3, lt = 4),
+  \(rtmp, lt){
+    exact_extract(
+      x = rtmp,
+      y = poly_simp_adm0,
+      fun = "mean",
+      append_cols = "adm0_es"
+    ) %>%
+      pivot_longer(-matches("adm0_es")) %>%
+      separate(name, into = c("stat", "date"), sep = "\\.") %>%
+      pivot_wider(names_from = "stat", values_from = "value") %>%
+      mutate(
+        date = as_date(date),
+        leadtime = lt
+      )
+  }
+)
+
+df_zonal_adm0 <- bind_rows(
+  df_zonal_historical_adm0,
+  df_zonal_latest_adm0
+) %>%
+  mutate(
+    # units are m/s - convert to meters: 60 s * 60 minutes * 24 hours * 30 days
+    # meters to mm = m * 1000
+    total_mean_mm = (mean * (60 * 60 * 24 * 30)) * 1000
+  )
+```
+
+# ECMWF Monthly Forecast values
+
+To simplify visual we just look at leadtime 1 values for all historical forecast records. Values summarised to 
+```{r}
+
+df_zonal_adm0 %>%
+  filter(leadtime == 1) %>%
+  ggplot(
+    aes(
+      x = date,
+      y = total_mean_mm,
+      group = adm0_es
+    )
+  ) +
+  geom_point(size= 1,alpha= 0.5) +
+  geom_line(alpha=0.5) +
+  facet_wrap(~adm0_es)+
+  labs(
+    title = "Mean Historical Precipitation Forecast (ECMWF)",
+    subtitle="Only leadtime 1 shown for simplification of visual",
+    y= "precipitation (mm)",
+    caption = "Source: ECMWF Monthly Forecast"
+  )+
+  theme(
+    axis.title.x = element_blank()
+  )
+  
+```
+
+Not a very useful visual - but leaving here:
+
+```{r}
+df_zonal_adm0 %>%
+  ggplot(
+    aes(
+      x = date,
+      y = total_mean_mm,
+      group = adm0_es
+    )
+  ) +
+  geom_point(size= 1,alpha= 0.5) +
+  geom_line(alpha=0.5) +
+  facet_wrap(~adm0_es)+
+  labs(
+    title = "Mean Historical Precipitation Forecast (ECMWF)",
+    subtitle="Across all leadtimes",
+    y= "precipitation (mm)",
+    caption = "Source: ECMWF Monthly Forecast"
+  )+
+  facet_grid(
+    # vars(adm0_es, leadtime),
+    cols=vars(leadtime),
+    rows=vars(adm0_es)
+    )+
+  theme(
+    axis.title.x = element_blank()
+  )
+```
+
+# Dryest Years as predicted by ECMWF
+```{r}
+df_zonal_regional_seas <- df_zonal_regional %>%
+  mutate(
+    mo = month(date),
+    yr = year(date)
+  ) %>%
+  mutate(
+    season = case_when(
+      mo %in% c(5, 6, 7) ~ "MJJ",
+      mo %in% c(6, 7, 8) ~ "JJA",
+      mo %in% c(9, 10, 11) ~ "SON",
+      .default = "no_window"
+    ),
+    season = fct_relevel(season, "MJJ", "JJA", "SON"),
+    yr_season = paste0(yr, "_", season)
+  ) %>%
+  # just do lt 1 for reference -- probably should do across all.
+  filter(leadtime == 1)
+
+df_min_per_season <- df_zonal_regional_seas %>%
+  group_by(yr_season, yr, season) %>%
+  summarise(
+    min = min(total_mean_mm),
+    avg = mean(total_mean_mm), .groups = "drop"
+  )
+
+
+df_min_of_min <- df_min_per_season %>%
+  group_by(season) %>%
+  slice_min(order_by = min, n = 5) %>%
+  ungroup() %>%
+  filter(season != "no_window")
+
+df_mean_of_min <- df_min_per_season %>%
+  group_by(season) %>%
+  slice_min(order_by = avg, n = 5) %>%
+  ungroup() %>%
+  filter(season != "no_window")
+
+
+
+df_el_nino_years <- tibble(
+  date =
+    c(
+      "1982-1983",
+      "1997-1998",
+      "2002-2003",
+      "2004-2005",
+      "2006-2007",
+      "2009-2010",
+      "2014-2016",
+      "2018-2019",
+      "2023-2024"
+    )
+) %>%
+  separate(
+    date,
+    into = c("start_date", "end_date"), sep = "-"
+  )
+
+df_el_nino_years <- df_el_nino_years %>%
+  mutate(
+    start_date = glue("{start_date}-01-01") %>% as_date(),
+    end_date = glue("{end_date}-12-31") %>% as_date()
+  )
+
+
+
+df_min_per_season %>%
+  filter(season != "no_window") %>%
+  mutate(
+    mo = case_when(
+      str_detect(season, "JJA") ~ "07",
+      str_detect(season, "MJJ") ~ "03",
+      str_detect(season, "SON") ~ "09",
+    ),
+    date = as_date(glue("{yr}-{mo}-01"))
+  ) %>%
+  mutate(
+    pt_label = ifelse(yr_season %in% df_mean_of_min$yr_season, yr, NA) %>%
+      as_factor(),
+    pt_color = yr_season %in% df_mean_of_min$yr_season
+  ) %>%
+  ggplot() +
+  scale_x_date(
+    date_breaks = "2 year",
+    date_labels = "%Y"
+  ) +
+  scale_y_reverse() +
+  geom_point(
+    aes(
+      x = date,
+      y = avg,
+      color = pt_color
+    )
+  ) +
+  geom_text(
+    aes(
+      label = pt_label,
+      x = date,
+      y = avg,
+      color = pt_color
+    ),
+    color = hdx_hex("tomato-hdx"), nudge_y = 20
+  ) +
+  geom_rect(
+    data = df_el_nino_years,
+    aes(
+      xmin = start_date,
+      xmax = end_date,
+      ymin = -Inf,
+      ymax = Inf
+    ),
+    alpha = 0.2,
+    fill = hdx_hex("tomato-hdx")
+  ) +
+  facet_wrap(~season, nrow = 33) +
+  labs(
+    title = "Dryest seasons according to ECMWF (LT 1) forecasts",
+    subtitle = "Central American Dry Corridor (el Nino years highlighted in red)",
+    y = "Monthly Average Precipitation (mm)"
+  ) +
+  theme(
+    legend.position = "none",
+    axis.title.x = element_blank(), 
+    panel.border = element_rect(color = "grey", fill = NA),
+    axis.text.x = element_text(angle = 90)
+  )
+```


### PR DESCRIPTION
This PR downloads all available historical ECMWF SEAS51 precipitation forecast data over the Central American Dry Corridor (CADC).

- IMHO - there is not really much to review - perhaps just a quick look at the download script here : `data-raw/ecmwf_seas51.R` ? Think the `exploration` folder can be ignored in this PR
- The reason I don't think it needs much review is because we are awaiting feedback from partners on which forecasts will be recommended (they are discussing national forecasts).  Therefore the purpose of this branch was just to set up the template for scripts to download the ECMWF data if necessary and become somewhat familiar. 
- This being said, i'd like to merge it mainly for the purpose of pruning/cleaning branches in the repo and my mind :-).
- This can be merged directly to the downstream branch (`iri-vhi-trigger-simulation`) or to `main` after `iri-vhi-trigger-simulation` is merged to main
- For a little additional background info: The monthly ECMWF forecasts don't really fit into the current framework which is based on 3-month tercile probability forecasts. We are toying with the idea of calculating transforming these data to that format, but it's out of scope of this branch which is mainly just downloading.


