### PR TITLE
Aoi refine 2025

### DIFF
--- a/analysis/05_2025_AOI_adjustments.qmd
+++ b/analysis/05_2025_AOI_adjustments.qmd
@@ -41,14 +41,20 @@ box::use(
   purrr[...],
   gghdx[...],
   ggplot2[...],
+  forcats[...],
   sf[...],
+  readr[...],
   
   lubridate[...],
   ggrepel[...],
-  gt,
+  gt[...],
+  geoarrow[...],
+  arrow[...],
   cumulus
 )
+
 gghdx()
+txt_label_size <- 3
 
 
 
@@ -69,8 +75,7 @@ threshold_var <-  function(df,var, by,rp_threshold,direction=1){
       ) |> 
       select(
         -rank,
-        -q_rank,
-        # -rp_emp
+        -q_rank
         )
   }
   if(direction == -1){
@@ -89,8 +94,7 @@ threshold_var <-  function(df,var, by,rp_threshold,direction=1){
       ) |> 
       select(
         -rank,
-        -q_rank,
-        # -rp_emp
+        -q_rank
         )
   }
   ret
@@ -136,6 +140,8 @@ df_new_aoi_meta <- df_poly_meta |>
 ## Map new AOI
 
 ```{r}
+#| eval: true
+
 
 lgdf_nic <- cumulus$download_fieldmaps_sf(iso3="nic",layer =c("nic_adm1","nic_adm0"))
 lgdf_hnd <- cumulus$download_fieldmaps_sf(iso3="hnd",layer=c("hnd_adm1","hnd_adm0"))
@@ -167,6 +173,39 @@ gdf_adm0_cadc <- list_rbind(
     geometry=geom
   )
 
+
+```
+
+```{r}
+#| eval: false
+
+cumulus$blob_write(
+  gdf_adm1_cadc,
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm1.parquet"
+  )
+cumulus$blob_write(
+  gdf_adm0_cadc,
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm0.parquet"
+  )
+
+gdf_adm1_cadc <- cumulus$blob_read(
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm1.parquet"
+  )
+
+gdf_adm0_cadc <- cumulus$blob_read(
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm0.parquet"
+  )
+
+
+```
+
+
+```{r}
+
 gdf_aoi <- gdf_adm1_cadc |> 
   filter(
     ADM1_PCODE %in% df_new_aoi_meta$pcode
@@ -187,14 +226,13 @@ ggplot()+
 
 Quickly checking the SEAS5 meta-data from our postgres DB to make sure the number of pixels per admin is adequate. Here are the pixels per admin
 ```{r}
-
 # quick check on number of pixels.
 df_new_aoi_meta |> 
   select(
     pcode, iso3, name,starts_with("seas5")
   ) |> 
-  gt$gt() |> 
-  gt$fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
+  gt() |> 
+  fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
 ```
 
 At the end of the day we will be aggregating per `country`/`iso3` so let's sum across countrys
@@ -207,8 +245,8 @@ df_new_aoi_meta |>
   summarise(
     across(where(is.numeric),\(x) sum(x))
   ) |> 
-  gt$gt() |> 
-  gt$fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
+  gt() |> 
+  fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
 ```
 
 ## Aggreate/Analyze Forecast
@@ -313,7 +351,7 @@ p_timeseries_refined_aoi <- ldf_thresholded |>
         ) +
         geom_text_repel(
           data= filter(dft_min,mm_flag),
-          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
         )+
         theme(
           axis.title = element_blank(),
@@ -425,7 +463,7 @@ p_timeseries_refined_aoi_1988_2022_base <- ldf_seas5_thresholded_w_recent |>
         ) +
         geom_text_repel(
           data= filter(dft_min,mm_flag),
-          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size= txt_label_size
         )+
         theme(
           axis.title = element_blank(),
@@ -493,7 +531,7 @@ df_insivumeh_zonal_min_per_year |>
   ) +
   geom_text_repel(
     data= filter(df_insivumeh_zonal_min_per_year,mm_flag),
-    aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+    aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"),size= txt_label_size
   )+
   theme(
     axis.title = element_blank(),
@@ -593,7 +631,7 @@ ldf_thresholds_wide <- split(df_thresholds_labelled,df_thresholds_labelled$seaso
   })
         
 
-txt_footnote <- "Threshold calculations are made based on analysis of historical forecast data (1981-2022) to approximate a 1 in 4 year return period drought levels for rainfall over the entire season. Thresholds are calculated per country, leadtime, and forecast data source to minimize potential biases. Where possible national forecasts were used for this analysis and monitoring. Where no national forecasts were readily available, ECMWF seasonal forecasts/historical forecasts were used. <br><br><b> Note:</b> The national forecast provided by INSIVUMEH in Guatemala does not provide a forecast estimate for the month of publication, therefore for the final month of primera monitoring we use ECMWF data for all 4 countries"
+txt_footnote <- "Threshold calculations are made based on analysis of historical forecast data (1981-2022) to approximate a 1 in 4 year return period drought levels for rainfall over the entire season. Thresholds are calculated per country, leadtime, and forecast data source to minimize potential biases. Where possible national forecasts were used for this analysis and monitoring. Where no national forecasts were readily available, ECMWF seasonal forecasts/historical forecasts were used. <br><br><b> Note:</b> The national forecast provided by INSIVUMEH in Guatemala does not provide a forecast estimate for the month of publication, therefore when that month is included as an activation moment, ECMWF is used."
 
 
 # set colors for table/legend
@@ -654,14 +692,14 @@ ldf_thresholds_wide$postrera %>%
     style = cell_fill(color = insuv_color),
     locations = cells_body(
       columns = c("Guatemala"), 
-      rows = 1:2
+      rows = 1:3
     )) %>% 
-  tab_style(
-    style = cell_fill(color = ecmwf_color),
-    locations = cells_body(
-      columns = c("Guatemala"), 
-      rows = 3
-    )) %>% 
+  # tab_style(
+  #   style = cell_fill(color = ecmwf_color),
+  #   locations = cells_body(
+  #     columns = c("Guatemala"), 
+  #     rows = 3
+  #   )) %>% 
   tab_footnote(footnote = html(txt_footnote)) %>% 
    tab_header(title = "Postrera (SON 2024) Rainfall (mm) Monitoring Thresholds",
              subtitle = gt_legend

--- a/analysis/05_2025_AOI_adjustments.qmd
+++ b/analysis/05_2025_AOI_adjustments.qmd
@@ -29,6 +29,7 @@ project:
 Analysis to assess potential to refine AOI for CADC
 
 ```{r}
+# rendered doc stored here: https://rpubs.com/zackarno/1268712
 #' analysis script to understand implication of changing AOI to select admin 1's
 
 box::use(

--- a/analysis/05_2025_AOI_adjustments.qmd
+++ b/analysis/05_2025_AOI_adjustments.qmd
@@ -1,7 +1,27 @@
 ---
-title: "AOI Refine"
-format: html
+title-block-banner: "#00ad78ff"
+title-block-banner-color: "#ffffff"
+title: CADC - 2025 Monitoring - AOI Adjustment Evaluation
+format:
+  html:
+    toc: true
+    toc-depth: 3
+    code-fold: true
+    self-contained: true
+    embed-resoures: true
+    smooth-scroll: true
+execute:
+  include: true
+  echo: true
+  warning: false
+  message: false
+  eval: true
+  results: "asis"
+  out.width: "100%"
+  code-fold: true
 editor: visual
+project:
+  execute-dir: project
 ---
 
 ## AOI Refinement
@@ -123,7 +143,7 @@ lgdf_slv <- cumulus$download_fieldmaps_sf(iso3="slv",layer=c("slv_adm1","slv_adm
 lgdf_gtm <- cumulus$download_fieldmaps_sf(iso3="gtm",layer=c("gtm_adm1","gtm_adm0"))
 
 
-gdf_adm1_cadc <- purrr$list_rbind(
+gdf_adm1_cadc <- list_rbind(
   list(
     lgdf_nic$nic_adm1,
     lgdf_hnd$hnd_adm1,
@@ -135,7 +155,7 @@ gdf_adm1_cadc <- purrr$list_rbind(
     geometry=geom
   )
 
-gdf_adm0_cadc <- purrr$list_rbind(
+gdf_adm0_cadc <- list_rbind(
   list(
     lgdf_nic$nic_adm0,
     lgdf_hnd$hnd_adm0,
@@ -192,6 +212,10 @@ df_new_aoi_meta |>
 ```
 
 ## Aggreate/Analyze Forecast
+
+### ECMWF SEAS5
+
+First we just look at ECMWF  - here we actually consider all leadtimes -- not just those considered for monitoring and we see no activations present in historical record. If we did see activations we would want to check on what leadtimes those occured.
 
 ```{r}  
 # Prep Seas5 --------------------------------------------------------------
@@ -310,10 +334,8 @@ p_timeseries_refined_aoi$postrera
 ```
 
 
-## Thresholds 
-
 - let's do simple linear interpolation of empirical RPs to calculate the thresholds - i think let's keep the historical record the same as 2024 monitoring 1981-2022
-- note that previously I had don't he RP by calculating the inverse of the percentile as defines in R base langauage. Now I'm using the classical empirical RP calculation to align better w/ new frameworks etc.
+- note that previously I had calculated empirical RP using the inverse of the percentile as defined by default settings in R  R base `stats::quantile()`.  However, now I'm using the classical empirical RP calculation to align better w/ new frameworks etc.
 
 - results unchanged
 ```{r}
@@ -324,6 +346,8 @@ ldf_thresholded_1981_2022 <- ldf_seas |>
         filter(
           year(issued_date)<=2022
         ) |> 
+        # this func classifies each record RP and creates a boolean of whether or not the threshold
+        # is passed. We ignore the boolean and just grab the rp_empiricaal values for interpolation
         threshold_var(
           var= "mm",
           by = c("iso3","leadtime"),
@@ -346,7 +370,7 @@ rp_linear_funcs <- ldf_thresholded_1981_2022 |>
           }
     )
 
-
+# interpolate for RP 4
 df_rp4_by_lt <- rp_linear_funcs |> 
   map(\(dft){
     dft |> 
@@ -354,14 +378,13 @@ df_rp4_by_lt <- rp_linear_funcs |>
       reframe(
         RP_empirical = 4,
         value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
-        # these values are exactly the same as already calculated in `df_lp3_rps` so this
-        # step is redundant, but will pack it in here anyways
-        # value_LP3 = map_dbl(RP_empirical,calc_lp3_rp_level),
-        # RP_LP3_calc = map_dbl(value_empirical,calc_lp3_rp)
       )
   }
   )
 
+# now we can compare the entire record to this interpolated RP 4. We basically had to this extra
+# step so that we could use the 1981-2022 as a baeline for creating the threshold. If we were
+# using the whole record the `threshold_var()` func would habe done it all.
 
 ldf_seas5_thresholded_w_recent <-   map(
     set_names(names(df_rp4_by_lt),names(df_rp4_by_lt)),
@@ -412,6 +435,8 @@ p_timeseries_refined_aoi_1988_2022_base <- ldf_seas5_thresholded_w_recent |>
   )
 ```
 
+We see that the results are still the same as previously when RP was calculated from all years on record 1981-2024
+
 ```{r}
 p_timeseries_refined_aoi_1988_2022_base$primera
 ```
@@ -419,4 +444,231 @@ p_timeseries_refined_aoi_1988_2022_base$primera
 ```{r}
 p_timeseries_refined_aoi_1988_2022_base$postrera
 ```
+
+### INSIVUMEH
+
+
+Looking at just INSIVUMEH historical activation record - again, we see again no activations in 2024.
+```{r}
+
+# We ran the same basic analysis for INSIVUMEH data in a separate R-script. As this required zonal stats on the raster files theselves, this was done in a separate rscript: `analysis/insivumeh_refined_aoi_zonal_stats.R` so that the intermediate outputs could be saved on blob to be pulled into this notebook for quicker/more effecient rendering.
+
+df_insivumeh_thresholds <- cumulus$blob_read(
+container = "projects",
+  name = "ds-aa-lac-dry-corridor/insivumeh_thresholds_aoi_chiquimula.parquet"
+)
+
+df_insivumeh_zonal <- cumulus$blob_read(
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/insivumeh_zonal_stats_seasonal_aoi_chiquimula.parquet"
+)
+
+df_insivumeh_zonal_min_per_year <- df_insivumeh_zonal |> 
+  left_join(
+    df_insivumeh_thresholds
+  ) |> 
+  mutate(
+    mm_flag = value<=value_empirical,
+    season= fct_relevel(season, "primera","postrera")
+  ) |> 
+  group_by(adm0_es,adm1_es,season,year(issued_date)) |> 
+  slice_min(
+    order_by = value, n= 1
+  ) 
+  
+
+df_insivumeh_zonal_min_per_year |> 
+  ggplot(
+    aes(x= year(issued_date),y=value, group = 1)
+  )+
+  geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+  geom_line(color = "black")+
+  facet_wrap(~season,scales="free", ncol=1)+
+  scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+  labs(
+    title = glue("Guatemala - INSIVUMEH - Forecasts"),
+    subtitle = "Chiquimula",
+    caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
+  ) +
+  geom_text_repel(
+    data= filter(df_insivumeh_zonal_min_per_year,mm_flag),
+    aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+  )+
+  theme(
+    axis.title = element_blank(),
+    legend.position = "none"
+  )
+
+```
+
+
+## Threshold Tables
+
+Let's remake threshold tables in case we want to update technical note in 2025:
+```{r}
+
+df_insivumeh_thresholds <- df_insivumeh_thresholds |> 
+  mutate(
+    iso3 = "GTM",
+    forecast_source = "INSIVUMEH"
+  )
+
+df_ecmwf_thresholds <- df_rp4_by_lt |> 
+  imap(\(dft,nmt){
+    dft |> 
+      mutate(
+        season = nmt
+      )
+    
+  }) |> 
+  list_rbind() |> 
+  mutate(
+    forecast_source = "ECMWF SEAS5"
+  )
+
+
+df_seas5_insiv_thresholds <- df_ecmwf_thresholds |> 
+  filter(
+    !(iso3 == "GTM" & leadtime %in% c(1:4))
+  ) |> 
+  bind_rows(
+    df_insivumeh_thresholds 
+  ) |> 
+  filter(
+        leadtime<=3
+      )
+
+
+df_thresholds_labelled <- df_seas5_insiv_thresholds %>% 
+  arrange(
+    iso3, season
+  ) |> 
+  # print(n=15) |> 
+  mutate(
+    pub_month_int = ifelse(season == "primera",5- leadtime,9-leadtime),
+    pub_month_chr = month(pub_month_int, label =T, abb=T),
+    pub_month_lt = paste0(pub_month_chr," (", leadtime,")"),
+    adm0_es = case_when(
+      iso3== "GTM"~"Guatemala",
+      iso3=="HND"~"Honduras",
+      iso3=="SLV"~"El Salvador",
+      iso3 == "NIC"~"Nicaragua"
+    )
+  ) %>% 
+  select(
+    adm0_es, 
+    pub_month_lt,
+    threshold = value_empirical,
+    season,
+    forecast_source
+  ) |> 
+  filter(
+    !str_detect(pub_month_lt,"Sep")
+  )
+  
+
+ldf_thresholds_wide <- split(df_thresholds_labelled,df_thresholds_labelled$season) %>% 
+  map(\(dft){
+    dft |> 
+    arrange(adm0_es) %>% 
+        select(-forecast_source,-season) |> 
+        filter(
+          !str_detect(pub_month_lt, "^Feb")
+        ) %>% 
+        pivot_wider(names_from = adm0_es,
+                    values_from =threshold
+        ) |> 
+        select(
+          pub_month_lt,
+          `El Salvador`,
+          Honduras,
+          Nicaragua,
+          Guatemala
+        ) %>%
+        arrange(
+          desc(parse_number(pub_month_lt))
+        )
+    
+  })
+        
+
+txt_footnote <- "Threshold calculations are made based on analysis of historical forecast data (1981-2022) to approximate a 1 in 4 year return period drought levels for rainfall over the entire season. Thresholds are calculated per country, leadtime, and forecast data source to minimize potential biases. Where possible national forecasts were used for this analysis and monitoring. Where no national forecasts were readily available, ECMWF seasonal forecasts/historical forecasts were used. <br><br><b> Note:</b> The national forecast provided by INSIVUMEH in Guatemala does not provide a forecast estimate for the month of publication, therefore for the final month of primera monitoring we use ECMWF data for all 4 countries"
+
+
+# set colors for table/legend
+ecmwf_cols <- c("El Salvador","Honduras","Nicaragua")
+ecmwf_color <- hdx_hex("mint-light")
+insuv_color <- hdx_hex("sapphire-light")
+
+
+# make legend for table MARS data
+gt_legend <- data.frame(
+  `Forecast Data Source` = "Forecast Data Source",
+  ecmwf = "ECMWF SEAS5" ,
+  insuv= "INSIVUMEH"
+  
+) %>% 
+  gt(rowname_col = "Forecast Data Source") %>%  
+  data_color(columns = "ecmwf", direction = "column",color=ecmwf_color) %>% 
+  data_color(columns = "insuv", direction = "column",color=insuv_color) %>% 
+  tab_options(
+    column_labels.hidden = T
+  ) %>% 
+  as_raw_html()
+
+
+ldf_thresholds_wide$primera %>% 
+  gt() %>% 
+  fmt_number(decimals = 0) %>% 
+  cols_label(
+    pub_month_lt = html("Publication Month<br>(leadtime)")
+  ) %>% 
+  data_color(columns = ecmwf_cols, direction = "column",color=ecmwf_color) %>% 
+  tab_style(
+    style = cell_fill(color = insuv_color),
+    locations = cells_body(
+      columns = c("Guatemala"), 
+      rows = 1:2
+    )) %>% 
+  tab_style(
+    style = cell_fill(color = ecmwf_color),
+    locations = cells_body(
+      columns = c("Guatemala"), 
+      rows = 3
+    )) %>% 
+  tab_footnote(footnote = html(txt_footnote)) %>% 
+  tab_header(title = "Primera (MJJA 2024) Rainfall (mm) Monitoring Thresholds",
+             subtitle = gt_legend
+  )
+
+
+ldf_thresholds_wide$postrera %>% 
+  gt() %>% 
+  fmt_number(decimals = 0) %>% 
+  cols_label(
+    pub_month_lt = html("Publication Month<br>(leadtime)")
+  ) %>% 
+  data_color(columns = ecmwf_cols, direction = "column",color=ecmwf_color) %>% 
+  tab_style(
+    style = cell_fill(color = insuv_color),
+    locations = cells_body(
+      columns = c("Guatemala"), 
+      rows = 1:2
+    )) %>% 
+  tab_style(
+    style = cell_fill(color = ecmwf_color),
+    locations = cells_body(
+      columns = c("Guatemala"), 
+      rows = 3
+    )) %>% 
+  tab_footnote(footnote = html(txt_footnote)) %>% 
+   tab_header(title = "Postrera (SON 2024) Rainfall (mm) Monitoring Thresholds",
+             subtitle = gt_legend
+  )
+
+
+
+```
+
 

--- a/analysis/05_2025_AOI_adjustments.qmd
+++ b/analysis/05_2025_AOI_adjustments.qmd
@@ -1,0 +1,422 @@
+---
+title: "AOI Refine"
+format: html
+editor: visual
+---
+
+## AOI Refinement
+
+Analysis to assess potential to refine AOI for CADC
+
+```{r}
+#' analysis script to understand implication of changing AOI to select admin 1's
+
+box::use(
+  dplyr[...],
+  tidyr[...],
+  janitor[...],
+  stringr[...],
+  glue[...],
+  rlang[...],
+  purrr[...],
+  gghdx[...],
+  ggplot2[...],
+  sf[...],
+  
+  lubridate[...],
+  ggrepel[...],
+  gt,
+  cumulus
+)
+gghdx()
+
+
+
+threshold_var <-  function(df,var, by,rp_threshold,direction=1){
+  if(direction==1){
+    ret <- df |> 
+      group_by(
+        across({{by}})
+      ) |> 
+      arrange(
+        desc(!!sym(var))
+      ) |> 
+      mutate(
+        rank = row_number(),
+        q_rank = rank/(max(rank)+1),
+        rp_emp = 1/q_rank,
+        !!sym(glue("{var}_flag")):= rp_emp>=rp_threshold
+      ) |> 
+      select(
+        -rank,
+        -q_rank,
+        # -rp_emp
+        )
+  }
+  if(direction == -1){
+    ret <- df |> 
+      group_by(
+        across({{by}})
+      ) |> 
+      arrange(
+        (!!sym(var))
+      ) |> 
+      mutate(
+        rank = row_number(),
+        q_rank = rank/(max(rank)+1),
+        rp_emp = 1/q_rank,
+        !!sym(glue("{var}_flag")):= rp_emp>=rp_threshold
+      ) |> 
+      select(
+        -rank,
+        -q_rank,
+        # -rp_emp
+        )
+  }
+  ret
+}
+```
+
+
+
+```{r}
+# Prep Meta Lookup --------------------------------------------------------
+con <- cumulus$pg_con()
+
+tbl_polys <- tbl(con,"polygon") |> 
+  filter(adm_level == 1)
+
+df_lookup <- cumulus$blob_load_admin_lookup() |> 
+  clean_names()
+
+df_polys <- tbl_polys |> 
+  filter(
+    iso3 %in% c("NIC","HND","SLV","GTM")
+  ) |> 
+  collect() |> 
+  clean_names()
+
+df_poly_meta <- df_polys |> 
+  left_join(
+    df_lookup |> 
+      select(iso3,matches("adm\\d"),matches("adm_level")) |> 
+      filter(adm_level ==1), by = c("iso3" = "iso3","pcode"="adm1_pcode","adm_level")
+  )
+
+df_new_aoi_meta <- df_poly_meta |> 
+  filter(
+    # just lazy regex to detect names provided to me in a teams chat -- the returned data.frame
+    # is correct -- for an official pipeline - we would hardcode these more explicitly
+    str_detect(
+      adm1_name, 
+      "San Vicente|El Paraiso|Francisco Morazan|Matagalpa|Estel|Nueva Segovia|Madriz|Chiquimula")
+  )
+```
+
+## Map new AOI
+
+```{r}
+
+lgdf_nic <- cumulus$download_fieldmaps_sf(iso3="nic",layer =c("nic_adm1","nic_adm0"))
+lgdf_hnd <- cumulus$download_fieldmaps_sf(iso3="hnd",layer=c("hnd_adm1","hnd_adm0"))
+lgdf_slv <- cumulus$download_fieldmaps_sf(iso3="slv",layer=c("slv_adm1","slv_adm0"))
+lgdf_gtm <- cumulus$download_fieldmaps_sf(iso3="gtm",layer=c("gtm_adm1","gtm_adm0"))
+
+
+gdf_adm1_cadc <- purrr$list_rbind(
+  list(
+    lgdf_nic$nic_adm1,
+    lgdf_hnd$hnd_adm1,
+    lgdf_slv$slv_adm1,
+    lgdf_gtm$gtm_adm1
+  )
+) |> 
+  rename(
+    geometry=geom
+  )
+
+gdf_adm0_cadc <- purrr$list_rbind(
+  list(
+    lgdf_nic$nic_adm0,
+    lgdf_hnd$hnd_adm0,
+    lgdf_slv$slv_adm0,
+    lgdf_gtm$gtm_adm0
+  )
+) |> 
+  rename(
+    geometry=geom
+  )
+
+gdf_aoi <- gdf_adm1_cadc |> 
+  filter(
+    ADM1_PCODE %in% df_new_aoi_meta$pcode
+  )
+
+ggplot()+
+  geom_sf(data =gdf_adm0_cadc,aes(geometry= geometry), fill ="white")+
+  geom_sf(data= gdf_aoi,aes(geometry=geometry), fill = "red")+
+  theme_void()+
+  theme(
+    panel.background = element_rect(fill = "lightblue"),
+    panel.grid = element_blank(),
+    plot.background = element_rect(fill = "lightblue")
+  )
+```
+
+
+
+Quickly checking the SEAS5 meta-data from our postgres DB to make sure the number of pixels per admin is adequate. Here are the pixels per admin
+```{r}
+
+# quick check on number of pixels.
+df_new_aoi_meta |> 
+  select(
+    pcode, iso3, name,starts_with("seas5")
+  ) |> 
+  gt$gt() |> 
+  gt$fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
+```
+
+At the end of the day we will be aggregating per `country`/`iso3` so let's sum across countrys
+```{r}
+df_new_aoi_meta |> 
+  select(
+    pcode, iso3, name,starts_with("seas5")
+  ) |> 
+  group_by(iso3) |> 
+  summarise(
+    across(where(is.numeric),\(x) sum(x))
+  ) |> 
+  gt$gt() |> 
+  gt$fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
+```
+
+## Aggreate/Analyze Forecast
+
+```{r}  
+# Prep Seas5 --------------------------------------------------------------
+
+df_seas5 <- tbl(con,"seas5") |> 
+  filter(
+    adm_level == 1,
+    pcode %in% df_new_aoi_meta$pcode,
+    month(valid_date)%in% c(5:11) # just grabbing all relevant months for both windows
+  ) |> 
+  collect() # this actually loads data into memory so can take a 10s or so.
+
+df_seas5 <- df_seas5 |> 
+  mutate(
+    precipitation = days_in_month(valid_date) * mean
+  )
+  
+
+df_primera <- cumulus$seas5_aggregate_forecast(
+    df_seas5,
+    value = "precipitation",
+  valid_months =c(5:8),
+  by = c("iso3", "pcode","issued_date")
+) |> 
+    filter(
+    month(issued_date)!=2 # remove Feb
+  )
+
+df_postrera <- cumulus$seas5_aggregate_forecast(
+  df_seas5,
+  valid_months =c(9:11),
+  value = "precipitation",
+  by = c("iso3", "pcode","issued_date")
+  )
+
+
+
+# Weighted Average of Forecast AOI ----------------------------------------
+
+ldf_seas <- list(
+  "primera"= df_primera,
+  "postrera" = df_postrera
+) |> 
+  map(
+    \(dft){
+      dft |> 
+        left_join(df_new_aoi_meta) |> 
+        group_by(iso3, issued_date, leadtime, valid_month_label) |> 
+        summarise(
+          mm = weighted.mean (precipitation, w =seas5_n_upsampled_pixels ),.groups="drop"
+        )
+    }
+  )
+
+ldf_thresholded <- ldf_seas |> 
+  map(
+    \(dft){
+      dft |> 
+        threshold_var(
+          var= "mm",
+          by = c("iso3","leadtime"),
+          rp_threshold = 4,
+          direction =-1
+        ) 
+    }
+  )
+
+```
+
+
+```{r}
+p_timeseries_refined_aoi <- ldf_thresholded |> 
+  imap(
+    \(dft,nmt){
+      month_range_temp <- ifelse(nmt == "primera","MJJA","SON")
+      dft_min <- dft |> 
+        # get min per issued date (across LTs)
+        group_by(iso3,year(issued_date)) |> 
+        slice_min(
+          order_by = mm, n= 1
+        ) 
+      dft_min |> 
+        ggplot(
+          aes(x= year(issued_date),y=mm, group = 1)
+        )+
+        geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+        geom_line(color = "black")+
+        facet_wrap(~iso3)+
+        scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+        labs(
+          title = glue("ECMWF SEAS {month_range_temp} Forecasts"),
+          subtitle = str_to_title(nmt),
+          caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
+        ) +
+        geom_text_repel(
+          data= filter(dft_min,mm_flag),
+          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+        )+
+        theme(
+          axis.title = element_blank(),
+          legend.position = "none"
+        )
+    }
+  )
+
+```
+
+Plot historical time series of minimum rainfall per season/yr for both Primera and Postrera
+```{r}
+p_timeseries_refined_aoi$primera
+```
+
+```{r}
+p_timeseries_refined_aoi$postrera
+```
+
+
+## Thresholds 
+
+- let's do simple linear interpolation of empirical RPs to calculate the thresholds - i think let's keep the historical record the same as 2024 monitoring 1981-2022
+- note that previously I had don't he RP by calculating the inverse of the percentile as defines in R base langauage. Now I'm using the classical empirical RP calculation to align better w/ new frameworks etc.
+
+- results unchanged
+```{r}
+ldf_thresholded_1981_2022 <- ldf_seas |> 
+  map(
+    \(dft){
+      dft |> 
+        filter(
+          year(issued_date)<=2022
+        ) |> 
+        threshold_var(
+          var= "mm",
+          by = c("iso3","leadtime"),
+          rp_threshold = 4,
+          direction =-1
+        ) 
+    }
+  )
+
+# now we can linearly interpolate:
+rp_linear_funcs <- ldf_thresholded_1981_2022 |> 
+  map(
+    \(dft){
+      dft |> 
+        group_by(iso3,leadtime) |> 
+        summarise(
+          calc_empirical_rp_level = list(approxfun(rp_emp, mm,method = "linear", rule =2,yright =Inf)),
+          calc_empirical_rp = list(approxfun( mm,rp_emp,method = "linear",rule =2))
+        )
+          }
+    )
+
+
+df_rp4_by_lt <- rp_linear_funcs |> 
+  map(\(dft){
+    dft |> 
+      group_by(iso3, leadtime) |> 
+      reframe(
+        RP_empirical = 4,
+        value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
+        # these values are exactly the same as already calculated in `df_lp3_rps` so this
+        # step is redundant, but will pack it in here anyways
+        # value_LP3 = map_dbl(RP_empirical,calc_lp3_rp_level),
+        # RP_LP3_calc = map_dbl(value_empirical,calc_lp3_rp)
+      )
+  }
+  )
+
+
+ldf_seas5_thresholded_w_recent <-   map(
+    set_names(names(df_rp4_by_lt),names(df_rp4_by_lt)),
+    \(season_temp){
+    season_temp <- "primera"
+    df_thresh <- df_rp4_by_lt[[season_temp]]
+    df_historical  = ldf_seas[[season_temp]]
+    df_historical |> 
+      left_join(df_thresh) |> 
+      mutate(
+        mm_flag = mm<=value_empirical
+      )
+  })
+
+p_timeseries_refined_aoi_1988_2022_base <- ldf_seas5_thresholded_w_recent |> 
+  imap(
+    \(dft,nmt){
+      month_range_temp <- ifelse(nmt == "primera","MJJA","SON")
+      dft_min <- dft |> 
+        # get min per issued date (across LTs)
+        group_by(iso3,year(issued_date)) |> 
+        slice_min(
+          order_by = mm, n= 1
+        ) 
+      dft_min |> 
+        ggplot(
+          aes(x= year(issued_date),y=mm, group = 1)
+        )+
+        geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+        geom_line(color = "black")+
+        facet_wrap(~iso3)+
+        scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+        labs(
+          title = glue("ECMWF SEAS {month_range_temp} Forecasts"),
+          subtitle = str_to_title(nmt),
+          caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
+        ) +
+        geom_text_repel(
+          data= filter(dft_min,mm_flag),
+          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+        )+
+        theme(
+          axis.title = element_blank(),
+          legend.position = "none"
+        )
+    }
+  )
+```
+
+```{r}
+p_timeseries_refined_aoi_1988_2022_base$primera
+```
+
+```{r}
+p_timeseries_refined_aoi_1988_2022_base$postrera
+```
+

--- a/analysis/05a_create_thresholds_geographically_refined_2025.R
+++ b/analysis/05a_create_thresholds_geographically_refined_2025.R
@@ -1,0 +1,346 @@
+#' code to make potential new threshodls for 2025 monitoring based on a
+#' new refined AOI of selected admin 1 levels.
+
+box::use(
+  ../src/datasources/insivumeh,
+  utils = ../ src/utils/gen_utils
+  )
+
+box::use(
+  terra, 
+  cumulus,
+  dplyr[...],
+  purrr[...],
+  sf[...],
+  exactextractr[...],
+  tidyr[...],
+  readr[...],
+  lubridate[...],
+  janitor[...],
+  
+  glue[...],
+  rlang[...],
+  ggplot2[...],
+  gghdx[...],
+  stringr[...],
+  ggrepel[...]
+  
+)
+gghdx()
+
+LAST_BASELINE_YEAR <-  2022
+AOI_SET_NAME <- "Selected admin 1's"
+OVERWRITE <- FALSE
+
+
+# Prep Meta Lookup --------------------------------------------------------
+
+df_aoi <- utils$load_aoi_df()
+
+df_lookup <- cumulus$blob_load_admin_lookup() |>
+  clean_names()
+
+
+con <- cumulus$pg_con()
+
+tbl_polys <- tbl(con,"polygon") |>
+  filter(adm_level == 1)
+
+df_polys <- tbl_polys |>
+  filter(
+    iso3 %in% c("NIC","HND","SLV","GTM")
+  ) |>
+  collect() |>
+  clean_names()
+
+
+
+df_poly_meta <- df_polys |>
+  left_join(
+    df_lookup |>
+      select(iso3,matches("adm\\d"),matches("adm_level")) |>
+      filter(adm_level ==1),
+    by = c("iso3" = "iso3","pcode"="adm1_pcode","adm_level")
+  )
+
+df_new_aoi_meta <- df_poly_meta |>
+  filter(
+    pcode %in% df_aoi$pcode
+  )
+
+
+
+# Prep Seas5 --------------------------------------------------------------
+
+df_seas5_adm1 <- tbl(con,"seas5") |> 
+  filter(
+    adm_level == 1,
+    pcode %in% df_aoi$pcode,
+    month(valid_date)%in% c(5:11) # just grabbing all relevant months for both windows
+  ) |> 
+  collect() # this actually loads data into memory so can take a 10s or so.
+
+df_seas5 <- df_seas5_adm1 |> 
+  mutate(
+    precipitation = days_in_month(valid_date) * mean
+  )
+
+
+df_primera <- cumulus$seas5_aggregate_forecast(
+  df_seas5,
+  value = "precipitation",
+  valid_months =c(5:8),
+  by = c("iso3", "pcode","issued_date")
+) 
+
+df_postrera <- cumulus$seas5_aggregate_forecast(
+  df_seas5,
+  valid_months =c(9:11),
+  value = "precipitation",
+  by = c("iso3", "pcode","issued_date")
+)
+
+
+
+# Weighted Average of Forecast AOI ----------------------------------------
+
+ldf_seas <- list(
+  "primera"= df_primera,
+  "postrera" = df_postrera
+) |> 
+  map(
+    \(dft){
+      dft |> 
+        left_join(df_new_aoi_meta, by =c("iso3", "pcode")) |> 
+        group_by(iso3, issued_date, leadtime, valid_month_label) |> 
+        summarise(
+          mm = weighted.mean (precipitation, w =seas5_n_upsampled_pixels ),
+          .groups="drop"
+        )
+    }
+  )
+
+
+ldf_thresholded_1981_2022 <- ldf_seas |> 
+  map(
+    \(dft){
+      dft |> 
+        mutate(
+          issued_month_label = month(issued_date,label = TRUE, abbr=T)
+        ) |> 
+        filter(
+          year(issued_date)<=LAST_BASELINE_YEAR
+        ) |> 
+        # this func classifies each record RP and creates a boolean of whether or not the threshold
+        # is passed. We ignore the boolean and just grab the rp_empiricaal values for interpolation
+        utils$threshold_var(
+          var= "mm",
+          by = c("iso3","leadtime",issued_month_label),
+          rp_threshold = 4,
+          direction =-1
+        ) 
+    }
+  )
+
+# now we can linearly interpolate:
+rp_linear_funcs <- ldf_thresholded_1981_2022 |> 
+  map(
+    \(dft){
+      dft |> 
+        group_by(iso3,leadtime, issued_month_label) |> 
+        summarise(
+          calc_empirical_rp_level = list(approxfun(rp_emp, mm,method = "linear", rule =2,yright =Inf)),
+          calc_empirical_rp = list(approxfun( mm,rp_emp,method = "linear",rule =2)),.groups="drop"
+        )
+    }
+  )
+
+# interpolate for RP 4
+df_seas5_thresholds <- rp_linear_funcs |> 
+  imap(\(dft,nmt){
+    dft |> 
+      group_by(iso3, leadtime, issued_month_label) |> 
+      reframe(
+        RP_empirical = 4,
+        value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
+      ) |> 
+      mutate(
+        window = nmt
+      )
+  }
+  ) |> 
+  list_rbind() |> 
+  mutate(
+    forecast_source = "SEAS5",
+    AOI = AOI_SET_NAME,
+    adm0_es = case_when(
+      iso3 == "GTM"~ "Guatemala",
+      iso3== "NIC"~"Nicaragua",
+      iso3== "HND"~"Honduras",
+      iso3=="SLV" ~ "El Salvador"
+    )
+  )
+
+
+
+
+# Insivumeh ---------------------------------------------------------------
+
+AOI_GTM <- df_new_aoi_meta |> 
+  filter(iso3=="GTM") |> 
+  pull(name)
+
+dir_insivumeh <- file.path(
+  Sys.getenv("AA_DATA_DIR_NEW"),
+  "private",
+  "raw",
+  "lac",
+  "INSIVUMEH"
+)
+
+dir_old <-  file.path(
+  dir_insivumeh,
+  "old_format"
+)
+
+# new format has new extent.
+dir_new <- file.path(
+  dir_insivumeh,
+  "new_format"
+)
+
+r_old <- insivumeh$load_ncdf_insivumeh(gdb = dir_old,wrap=F)
+r_new <- insivumeh$load_ncdf_insivumeh(gdb = dir_new,wrap=F)
+
+
+gdf_adm1 <- cumulus$download_fieldmaps_sf(iso = "gtm",layer = "gtm_adm1")$gtm_adm1
+
+gdf_gtm_aoi <- gdf_adm1 |> 
+  filter(
+    ADM1_ES == AOI_GTM
+  )
+
+
+lr <- list(
+  "old" = r_old,
+  "new" = r_new
+)
+
+# since new format has new extent, we just run the zonal statistics separtely
+ldf <- map(lr,\(x){
+  dft <- exact_extract(
+    x = x,
+    y = gdf_gtm_aoi,
+    fun = "mean"
+  )
+  dft |> 
+    pivot_longer(everything()) %>%
+    separate(name, into = c("stat", "issued_date", "lt_chr"), sep = "\\.") %>%
+    mutate(
+      adm0_es = "Guatemala",
+      adm1_es = AOI_GTM,
+      issued_date = as_date(issued_date),
+      leadtime = parse_number(lt_chr),
+      valid_date = issued_date + months(leadtime)
+    )
+}
+)
+
+dfz <- list_rbind(ldf)
+
+
+
+# `cumulus$seas5_aggregate_forecast()` basically should work perfectly 
+# for any seasonal monthly forecast.. perhaps i should change the name in
+# the package
+df_primera_insiv <- cumulus$seas5_aggregate_forecast(
+  dfz,
+  value ="value",
+  valid_months = c(5:8),
+  by = c("adm0_es","adm1_es","issued_date")
+)
+
+
+df_postrera_insiv <- cumulus$seas5_aggregate_forecast(
+  dfz,
+  value ="value",
+  valid_months = c(9:11),
+  by = c("adm0_es","adm1_es","issued_date")
+)
+
+ldf_insiv <- list(
+  "primera"= df_primera_insiv,
+  "postrera"= df_postrera_insiv
+)
+
+
+ldf_thresholded_1981_2022 <- ldf_insiv |> 
+  map(
+    \(dft){
+      dft |> 
+        filter(
+          year(issued_date)<=LAST_BASELINE_YEAR
+        ) |> 
+        utils$threshold_var(
+          var= "value",
+          by = c("adm0_es","adm1_es","leadtime"),
+          rp_threshold = 4,
+          direction =-1
+        ) 
+    }
+  )
+
+# now we can linearly interpolate:
+rp_linear_funcs <- ldf_thresholded_1981_2022 |> 
+  map(
+    \(dft){
+      dft |> 
+        group_by(adm0_es,adm1_es,issued_month_label = month(issued_date,abbr=T,label = T),leadtime) |> 
+        summarise(
+          calc_empirical_rp_level = list(approxfun(rp_emp, value,method = "linear", rule =2,yright =Inf)),
+          calc_empirical_rp = list(approxfun( value,rp_emp,method = "linear",rule =2))
+        )
+    }
+  )
+
+
+ldf_rp4_by_lt <- rp_linear_funcs |> 
+  map(\(dft){
+    dft |> 
+      group_by(adm0_es,adm1_es, leadtime,issued_month_label) |> 
+      reframe(
+        RP_empirical = 4,
+        value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
+      )
+  }
+  )
+
+df_insiv_thresholds <- ldf_rp4_by_lt |> 
+  imap(\(x,nmt){
+    x |> 
+      mutate(
+        window = nmt
+      )
+  }
+  ) |> 
+  list_rbind() |> 
+  mutate(
+    forecast_source = "INSIVUMEH",
+    AOI = AOI_SET_NAME,
+    iso3 = "GTM"
+  ) |> 
+  select(-adm1_es)
+
+df_combined_thresholds <- bind_rows(
+  df_seas5_thresholds,
+  df_insiv_thresholds
+)
+
+
+if(OVERWRITE){
+  cumulus$blob_write(
+    df = df_combined_thresholds,
+    container = "projects",
+    name = "ds-aa-lac-dry-corridor/framework_update_2025/df_thresholds_seas5_insivumeh_adm1_refined.parquet"
+  )  
+}

--- a/analysis/05b_2025_AOI_adjustments.qmd
+++ b/analysis/05b_2025_AOI_adjustments.qmd
@@ -137,8 +137,7 @@ df_new_aoi_meta <- df_poly_meta |>
 ## Map new AOI
 
 ```{r}
-#| eval: true
-
+#| eval: false
 
 lgdf_nic <- cumulus$download_fieldmaps_sf(iso3="nic",layer =c("nic_adm1","nic_adm0"))
 lgdf_hnd <- cumulus$download_fieldmaps_sf(iso3="hnd",layer=c("hnd_adm1","hnd_adm0"))
@@ -171,12 +170,6 @@ gdf_adm0_cadc <- list_rbind(
   )
 
 
-```
-
-```{r}
-#| eval: false
-#| echo: false
-
 cumulus$blob_write(
   gdf_adm1_cadc,
   container = "projects",
@@ -188,21 +181,33 @@ cumulus$blob_write(
   name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm0.parquet"
   )
 
+```
+
+```{r}
+#| eval: true
+#| echo: false
+
+# read
 gdf_adm1_cadc <- cumulus$blob_read(
   container = "projects",
-  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm1.parquet"
-  )
+  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm1.parquet",
+  as_data_frame =FALSE
+  ) |> 
+  st_as_sf()
 
 gdf_adm0_cadc <- cumulus$blob_read(
   container = "projects",
-  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm0.parquet"
-  )
+  name =  "ds-aa-lac-dry-corridor/framework_update_2025/gdf_cadc_adm0.parquet",
+  as_data_frame = FALSE
+  ) |> 
+  st_as_sf()
 
 
 ```
 
-```{r}
 
+
+```{r}
 gdf_aoi <- gdf_adm1_cadc |> 
   filter(
     ADM1_PCODE %in% df_new_aoi_meta$pcode
@@ -250,7 +255,7 @@ df_new_aoi_meta |>
 
 ### ECMWF SEAS5
 
-First we just look at ECMWF - here we actually consider all leadtimes -- not just those considered for monitoring and we see no activations present in historical record. If we did see activations we would want to check on what leadtimes those occured.
+First we just look at ECMWF - here we actually consider all leadtimes -- not just those considered for monitoring and we see no activations present in historical record. If we did see activation we would want to check on what lead times those occured.
 
 ```{r}
 # Prep Seas5 --------------------------------------------------------------
@@ -327,12 +332,14 @@ df_historical_aa_classified <- df_historical_aa_adm0 |>
 
 ```
 
-Plot historical time series of minimum rainfall per season/yr for both Primera and Postrera
+
+
+Plot historical time series of minimum rainfall per season/yr for both Primera and Postrera. In this plot the threshold is calculated form the entire historical record using all available data
 
 ```{r}
 #| fig.height: 8
 
-df_min_forecast_per_year_window <- df_historical_aa_classified |> 
+df_max_rp_forecast_per_year_window <- df_historical_aa_classified |> 
   # get min per issued date (across LTs)
   group_by(iso3,year(issued_date),window) |> 
   slice_max(
@@ -344,7 +351,7 @@ df_min_forecast_per_year_window <- df_historical_aa_classified |>
   )
     
 
-df_min_forecast_per_year_window |> 
+df_max_rp_forecast_per_year_window |> 
   ggplot(
     aes(x= year(issued_date),y=mm, group = 1)
   )+
@@ -370,10 +377,7 @@ df_min_forecast_per_year_window |>
 
 ```
 
--   let's do simple linear interpolation of empirical RPs to calculate the thresholds - i think let's keep the historical record the same as 2024 monitoring 1981-2022
-
--   note that previously I had calculated empirical RP using the inverse of the percentile as defined by default settings in R R base `stats::quantile()`. However, now I'm using the classical empirical RP calculation to align better w/ new frameworks etc.
-
+-   Below we plot the same thing, but to be more exact on the question of what would have happened in 2024 with the same method we calculate the thresholds using the same set of baseline years used to the 2024 monitoring (1984-2022) 
 -   results unchanged
 
 ```{r}
@@ -391,7 +395,7 @@ df_classified_2024_seas5_thresholds <- df_historical_aa_classified |>
   )
 
 
-df_min_2024_seas5_thresholds <- df_classified_2024_seas5_thresholds |> 
+df_max_rp_2024_seas5_thresholds <- df_classified_2024_seas5_thresholds |> 
   # get min per issued date (across LTs)
   group_by(iso3,year(issued_date),window) |> 
   slice_max(
@@ -406,7 +410,7 @@ df_min_2024_seas5_thresholds <- df_classified_2024_seas5_thresholds |>
 
 
 
-df_min_2024_seas5_thresholds |> 
+df_max_rp_2024_seas5_thresholds |> 
   ggplot(
     aes(x= year(issued_date),y=mm, group = 1)
   )+
@@ -460,7 +464,8 @@ df_insivumeh_zonal_min_per_year <- df_insivumeh_aa |>
   ) |> 
   group_by(adm0_es,adm1_es,window,year(issued_date)) |> 
   slice_min(
-    order_by = value, n= 1
+    # just plot the value closest to the threshold  per year/season
+    order_by = abs(value-value_empirical), n= 1
   ) 
   
 
@@ -507,7 +512,7 @@ df_thresholds_aa <- df_combined_thresholds |>
   )
   
 
-df_thresholds_labelled <- df_thresholds_aa %>% 
+df_thresholds_formatted <- df_thresholds_aa %>% 
   arrange(
     iso3, window
   ) |> 
@@ -525,7 +530,7 @@ df_thresholds_labelled <- df_thresholds_aa %>%
     forecast_source
   ) 
 
-ldf_thresholds_wide <- split(df_thresholds_labelled,df_thresholds_labelled$window) %>% 
+ldf_thresholds_wide <- split(df_thresholds_formatted,df_thresholds_formatted$window) %>% 
   map(\(dft){
     dft |> 
     arrange(adm0_es) %>% 
@@ -619,3 +624,216 @@ ldf_thresholds_wide$postrera %>%
   )
 
 ```
+
+## Joint RPs
+
+Next we want to look at how the joint return periods/activation rates could theoretically change using the refined AOI methodology
+```{r}
+
+# bind together all 
+df_all_forecasts <- bind_rows(
+  df_insivumeh_aa |> 
+    mutate(
+      forecast_source = "INSIVUMEH",
+      iso3 = "GTM"
+    ),
+  df_historical_aa_adm0 |> 
+    mutate(
+      forecast_source = "SEAS5"
+    ) |> 
+    rename(
+      value =mm
+    )
+) |> 
+  select(-adm0_es)
+
+
+# classify all forecasts as above or below threshold
+df_all_historical_forecasts_classified <- df_all_forecasts |> 
+  left_join(
+    df_combined_thresholds
+  ) |> 
+    mutate(
+    flag = value<= value_empirical
+  )
+```
+
+
+```{r}
+#| eval: false
+#| echo: false # dont need to show this in rendered doc
+
+
+# nice verification -- activation rates approximate 0.25% 1
+df_all_historical_forecasts_classified |> 
+  group_by(
+    iso3, leadtime,forecast_source
+  ) |> 
+  summarise(
+    ar = mean(flag)
+  )
+```
+
+
+
+```{r}
+# now filter to only relevant  forecast sources for monitoring
+
+df_historical_forecasts_classified_filtered <- df_all_historical_forecasts_classified |> 
+  filter(
+    !(iso3 =="GTM" & leadtime>0 & forecast_source=="SEAS5")
+  ) |> 
+  mutate(
+        adm0_es = case_when(
+      iso3== "GTM"~"Guatemala",
+      iso3 == "HND"~"Honduras",
+      iso3=="NIC"~"Nicaragua",
+      iso3=="SLV"~ "El Salvador"
+    )
+  )
+
+# get activation rates per window over all leadtimes
+df_jrp_window <- df_historical_forecasts_classified_filtered |> 
+  group_by(iso3,adm0_es, year(issued_date),window) |> 
+  summarise(
+    flag = any(flag)
+  ) |> 
+  group_by(iso3,adm0_es,window) |> 
+  summarise(
+    ar = mean(flag),
+    rp = 1/ar,
+    .groups="drop"
+  )
+
+# get activation rates across both windows -- activation rate of either occuring
+df_jrp_both_windows <- df_historical_forecasts_classified_filtered |> 
+  group_by(iso3, adm0_es,year(issued_date)) |> 
+  summarise(
+    flag = any(flag)
+  ) |> 
+  group_by(iso3,adm0_es) |> 
+  summarise(
+    ar = mean(flag),
+    rp = 1/ar,.groups="drop"
+  )
+
+
+df_jrp_per_window_wide <- df_jrp_window |> 
+  select(-iso3) |> 
+  pivot_wider(
+    names_from= adm0_es,
+    values_from = ar:rp
+  ) 
+
+df_jrp_both_windows_wide <- df_jrp_both_windows |> 
+    select(-iso3) |> 
+  pivot_wider(
+    names_from= adm0_es,
+    values_from = ar:rp
+  ) |> 
+  mutate(
+    window = "Combined"
+  )
+```
+
+
+```{r}
+bind_rows(df_jrp_per_window_wide,
+          df_jrp_both_windows_wide
+          ) |> 
+  
+  gt() |> 
+  fmt_percent(starts_with("ar"),decimals = 0) |> 
+  fmt_number(starts_with("rp"), decimals=1) |> 
+     cols_merge(
+    columns = c(`rp_El Salvador`, `ar_El Salvador`),
+    pattern = "{1} ({2})"
+  ) %>% 
+   cols_merge(
+    columns = c(`rp_Nicaragua`, `ar_Nicaragua`),
+    pattern = "{1} ({2})"
+  ) %>% 
+   cols_merge(
+    columns = c(`rp_Honduras`, `ar_Honduras`),
+    pattern = "{1} ({2})"
+  ) %>% 
+   cols_merge(
+    columns = c(`rp_Guatemala`, `ar_Guatemala`),
+    pattern = "{1} ({2})"
+  ) %>% 
+  cols_label(
+    "rp_El Salvador" = "El Salvador",
+    "rp_Guatemala" = "Guatemala",
+    "rp_Nicaragua" = "Nicaragua",
+    "rp_Honduras" = "Honduras",
+  ) |> 
+  tab_header(
+    title=  "Joint Return Periods/Activation Rate (selected admin 1 AOI)",
+    subtitle = "Across all monitored leadtimes and windows"
+  ) |> 
+  tab_options(
+    heading.background.color = "#00ad78ff",
+    column_labels.background.color = hdx_hex("mint-ultra-light")
+  )
+
+```
+
+
+```{r 2025_season}
+#| eval: false
+#| echo: true
+
+# one-off quick look at the upcoming season. Don't need to render this, but can keep in here for now
+# don't have INSIVUMEH data yet, so just doing on ECMWF SEAS5
+
+df_primera_feb <- df_primera |> 
+    mutate(
+    window = "primera"
+  ) |> 
+  left_join(df_new_aoi_meta) |> 
+  group_by(iso3, issued_date, leadtime, valid_month_label,window) |> 
+  summarise(
+    mm = weighted.mean (precipitation, w =seas5_n_upsampled_pixels ),.groups="drop"
+  ) |> 
+  filter(
+    month(issued_date) ==2
+  ) |> 
+  left_join(
+    df_combined_thresholds |> 
+      filter(
+    forecast_source == "SEAS5", issued_month_label =="Feb"
+  )
+  ) |> 
+  mutate(
+    mm_flag = mm<=value_empirical
+  )
+  
+
+df_primera_feb |> 
+  ggplot(
+    aes(x= year(issued_date),y=mm, group = 1)
+  )+
+  geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+  geom_line(color = "black")+
+  facet_grid(rows = vars(iso3))+
+  scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+  scale_x_continuous(breaks = 1981:2025) |> 
+  labs(
+    title = "CADC: Primera (MJJA) & Postrera (SON) Seasonal Precipitation Forecasts",
+    subtitle = "February publications: Selected admin 1 units in CADC",
+    caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
+  ) +
+  geom_text_repel(
+    data= filter(df_primera_feb,mm_flag),
+    aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
+  )+
+  geom_hline(
+    data = distinct(df_primera_feb,iso3,value_empirical),
+             aes(yintercept = value_empirical), color =hdx_hex("tomato-hdx"), linetype ="dashed")+
+  theme(
+    axis.title = element_blank(),
+    legend.position = "none"
+  )
+```
+

--- a/analysis/05b_2025_AOI_adjustments.qmd
+++ b/analysis/05b_2025_AOI_adjustments.qmd
@@ -54,55 +54,48 @@ box::use(
   cumulus
 )
 
+box::use(
+  utils = ../ src/utils/gen_utils
+)
+
 gghdx()
 txt_label_size <- 3
 
 
+df_combined_thresholds <- cumulus$blob_read(
+    container = "projects",
+    name = "ds-aa-lac-dry-corridor/framework_update_2025/df_thresholds_seas5_insivumeh_adm1_refined.parquet"
+  )
 
-threshold_var <-  function(df,var, by,rp_threshold,direction=1){
-  if(direction==1){
-    ret <- df |> 
-      group_by(
-        across({{by}})
-      ) |> 
-      arrange(
-        desc(!!sym(var))
-      ) |> 
-      mutate(
-        rank = row_number(),
-        q_rank = rank/(max(rank)+1),
-        rp_emp = 1/q_rank,
-        !!sym(glue("{var}_flag")):= rp_emp>=rp_threshold
-      ) |> 
-      select(
-        -rank,
-        -q_rank
-        )
-  }
-  if(direction == -1){
-    ret <- df |> 
-      group_by(
-        across({{by}})
-      ) |> 
-      arrange(
-        (!!sym(var))
-      ) |> 
-      mutate(
-        rank = row_number(),
-        q_rank = rank/(max(rank)+1),
-        rp_emp = 1/q_rank,
-        !!sym(glue("{var}_flag")):= rp_emp>=rp_threshold
-      ) |> 
-      select(
-        -rank,
-        -q_rank
-        )
-  }
-  ret
-}
+
+# insivumeh zonal stats from parquet on blob - - not ecmwf comes from postgres in code below
+df_insivumeh_zonal <- cumulus$blob_read(
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/insivumeh_zonal_stats_seasonal_aoi_chiquimula.parquet"
+)
+
+
+df_aoi <- utils$load_aoi_df()
 ```
 
+```{r}
 
+tibble::tribble(
+          ~Country,                                                                           ~Departments,
+     "El Salvador",                                                                          "San Vicente",
+        "Honduras", "El Paraíso (Texiguat, Vado Ancho) and Francisco Morazán (Curarén, Alubarén, Reitoca)",
+       "Nicaragua",                                          "Matagalpa, Estelí, Nueva Segovia and Madriz",
+       "Guatemala",                                 "Chiquimula (Jocotán, Camotán, and San José La Arada)"
+     ) |> 
+  gt() |> 
+  tab_header(
+    "Analysis filtered to admin 1's listed under departments"
+  ) |> 
+  tab_options(
+       heading.background.color = "#00ad78ff",
+    column_labels.background.color = hdx_hex("mint-ultra-light")
+  )
+```
 
 ```{r}
 # Prep Meta Lookup --------------------------------------------------------
@@ -125,7 +118,8 @@ df_poly_meta <- df_polys |>
   left_join(
     df_lookup |> 
       select(iso3,matches("adm\\d"),matches("adm_level")) |> 
-      filter(adm_level ==1), by = c("iso3" = "iso3","pcode"="adm1_pcode","adm_level")
+      filter(adm_level ==1),
+    by = c("iso3" = "iso3","pcode"="adm1_pcode","adm_level")
   )
 
 df_new_aoi_meta <- df_poly_meta |> 
@@ -136,6 +130,8 @@ df_new_aoi_meta <- df_poly_meta |>
       adm1_name, 
       "San Vicente|El Paraiso|Francisco Morazan|Matagalpa|Estel|Nueva Segovia|Madriz|Chiquimula")
   )
+
+
 ```
 
 ## Map new AOI
@@ -179,6 +175,7 @@ gdf_adm0_cadc <- list_rbind(
 
 ```{r}
 #| eval: false
+#| echo: false
 
 cumulus$blob_write(
   gdf_adm1_cadc,
@@ -204,7 +201,6 @@ gdf_adm0_cadc <- cumulus$blob_read(
 
 ```
 
-
 ```{r}
 
 gdf_aoi <- gdf_adm1_cadc |> 
@@ -223,9 +219,8 @@ ggplot()+
   )
 ```
 
-
-
 Quickly checking the SEAS5 meta-data from our postgres DB to make sure the number of pixels per admin is adequate. Here are the pixels per admin
+
 ```{r}
 # quick check on number of pixels.
 df_new_aoi_meta |> 
@@ -236,7 +231,8 @@ df_new_aoi_meta |>
   fmt_number(columns ="seas5_frac_raw_pixels",decimals = 2)
 ```
 
-At the end of the day we will be aggregating per `country`/`iso3` so let's sum across countrys
+At the end of the day we will be aggregating per `country`/`iso3` so let's sum across countries
+
 ```{r}
 df_new_aoi_meta |> 
   select(
@@ -254,15 +250,15 @@ df_new_aoi_meta |>
 
 ### ECMWF SEAS5
 
-First we just look at ECMWF  - here we actually consider all leadtimes -- not just those considered for monitoring and we see no activations present in historical record. If we did see activations we would want to check on what leadtimes those occured.
+First we just look at ECMWF - here we actually consider all leadtimes -- not just those considered for monitoring and we see no activations present in historical record. If we did see activations we would want to check on what leadtimes those occured.
 
-```{r}  
+```{r}
 # Prep Seas5 --------------------------------------------------------------
 
 df_seas5 <- tbl(con,"seas5") |> 
   filter(
     adm_level == 1,
-    pcode %in% df_new_aoi_meta$pcode,
+    pcode %in% df_aoi$pcode,
     month(valid_date)%in% c(5:11) # just grabbing all relevant months for both windows
   ) |> 
   collect() # this actually loads data into memory so can take a 10s or so.
@@ -272,15 +268,22 @@ df_seas5 <- df_seas5 |>
     precipitation = days_in_month(valid_date) * mean
   )
   
-
+filter_historical_to_moments <-  function(df,window_col){
+  df |> 
+    filter(
+      !(month(issued_date)==2 & !!sym(window_col)=="primera"),
+      !(month(issued_date) %in% c(5,9) & !!sym(window_col)=="postrera")
+    )
+    
+}
 df_primera <- cumulus$seas5_aggregate_forecast(
     df_seas5,
     value = "precipitation",
   valid_months =c(5:8),
   by = c("iso3", "pcode","issued_date")
 ) |> 
-    filter(
-    month(issued_date)!=2 # remove Feb
+  mutate(
+    window = "primera"
   )
 
 df_postrera <- cumulus$seas5_aggregate_forecast(
@@ -288,229 +291,174 @@ df_postrera <- cumulus$seas5_aggregate_forecast(
   valid_months =c(9:11),
   value = "precipitation",
   by = c("iso3", "pcode","issued_date")
+  ) |> 
+  mutate(
+    window = "postrera"
   )
+df_historical <- bind_rows(
+  df_primera,
+  df_postrera
+)
+
+df_historical_aa <- df_historical |> 
+  filter_historical_to_moments(
+    window_col ="window"
+    )
 
 
 
 # Weighted Average of Forecast AOI ----------------------------------------
 
-ldf_seas <- list(
-  "primera"= df_primera,
-  "postrera" = df_postrera
-) |> 
-  map(
-    \(dft){
-      dft |> 
-        left_join(df_new_aoi_meta) |> 
-        group_by(iso3, issued_date, leadtime, valid_month_label) |> 
-        summarise(
-          mm = weighted.mean (precipitation, w =seas5_n_upsampled_pixels ),.groups="drop"
-        )
-    }
+df_historical_aa_adm0 <- df_historical_aa |> 
+  left_join(df_new_aoi_meta) |> 
+  group_by(iso3, issued_date, leadtime, valid_month_label,window) |> 
+  summarise(
+    mm = weighted.mean (precipitation, w =seas5_n_upsampled_pixels ),.groups="drop"
   )
 
-ldf_thresholded <- ldf_seas |> 
-  map(
-    \(dft){
-      dft |> 
-        threshold_var(
-          var= "mm",
-          by = c("iso3","leadtime"),
-          rp_threshold = 4,
-          direction =-1
-        ) 
-    }
-  )
+df_historical_aa_classified <- df_historical_aa_adm0 |> 
+  utils$threshold_var(
+    var= "mm",
+    by = c("iso3","leadtime","window"),
+    rp_threshold = 4,
+    direction =-1
+  ) 
 
-```
-
-
-```{r}
-p_timeseries_refined_aoi <- ldf_thresholded |> 
-  imap(
-    \(dft,nmt){
-      month_range_temp <- ifelse(nmt == "primera","MJJA","SON")
-      dft_min <- dft |> 
-        # get min per issued date (across LTs)
-        group_by(iso3,year(issued_date)) |> 
-        slice_min(
-          order_by = mm, n= 1
-        ) 
-      dft_min |> 
-        ggplot(
-          aes(x= year(issued_date),y=mm, group = 1)
-        )+
-        geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
-        geom_line(color = "black")+
-        facet_wrap(~iso3)+
-        scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
-        labs(
-          title = glue("ECMWF SEAS {month_range_temp} Forecasts"),
-          subtitle = str_to_title(nmt),
-          caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
-          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
-        ) +
-        geom_text_repel(
-          data= filter(dft_min,mm_flag),
-          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
-        )+
-        theme(
-          axis.title = element_blank(),
-          legend.position = "none"
-        )
-    }
-  )
 
 ```
 
 Plot historical time series of minimum rainfall per season/yr for both Primera and Postrera
-```{r}
-p_timeseries_refined_aoi$primera
-```
 
 ```{r}
-p_timeseries_refined_aoi$postrera
-```
+#| fig.height: 8
 
-
-- let's do simple linear interpolation of empirical RPs to calculate the thresholds - i think let's keep the historical record the same as 2024 monitoring 1981-2022
-- note that previously I had calculated empirical RP using the inverse of the percentile as defined by default settings in R  R base `stats::quantile()`.  However, now I'm using the classical empirical RP calculation to align better w/ new frameworks etc.
-
-- results unchanged
-```{r}
-ldf_thresholded_1981_2022 <- ldf_seas |> 
-  map(
-    \(dft){
-      dft |> 
-        filter(
-          year(issued_date)<=2022
-        ) |> 
-        # this func classifies each record RP and creates a boolean of whether or not the threshold
-        # is passed. We ignore the boolean and just grab the rp_empiricaal values for interpolation
-        threshold_var(
-          var= "mm",
-          by = c("iso3","leadtime"),
-          rp_threshold = 4,
-          direction =-1
-        ) 
-    }
+df_min_forecast_per_year_window <- df_historical_aa_classified |> 
+  # get min per issued date (across LTs)
+  group_by(iso3,year(issued_date),window) |> 
+  slice_max(
+    order_by = rp_emp, n= 1,with_ties = F
+  ) |> 
+  ungroup() |> 
+  mutate(
+    window = factor(window, levels =c("primera","postrera"))
   )
+    
 
-# now we can linearly interpolate:
-rp_linear_funcs <- ldf_thresholded_1981_2022 |> 
-  map(
-    \(dft){
-      dft |> 
-        group_by(iso3,leadtime) |> 
-        summarise(
-          calc_empirical_rp_level = list(approxfun(rp_emp, mm,method = "linear", rule =2,yright =Inf)),
-          calc_empirical_rp = list(approxfun( mm,rp_emp,method = "linear",rule =2))
-        )
-          }
-    )
-
-# interpolate for RP 4
-df_rp4_by_lt <- rp_linear_funcs |> 
-  map(\(dft){
-    dft |> 
-      group_by(iso3, leadtime) |> 
-      reframe(
-        RP_empirical = 4,
-        value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
-      )
-  }
-  )
-
-# now we can compare the entire record to this interpolated RP 4. We basically had to this extra
-# step so that we could use the 1981-2022 as a baeline for creating the threshold. If we were
-# using the whole record the `threshold_var()` func would habe done it all.
-
-ldf_seas5_thresholded_w_recent <-   map(
-    set_names(names(df_rp4_by_lt),names(df_rp4_by_lt)),
-    \(season_temp){
-    season_temp <- "primera"
-    df_thresh <- df_rp4_by_lt[[season_temp]]
-    df_historical  = ldf_seas[[season_temp]]
-    df_historical |> 
-      left_join(df_thresh) |> 
-      mutate(
-        mm_flag = mm<=value_empirical
-      )
-  })
-
-p_timeseries_refined_aoi_1988_2022_base <- ldf_seas5_thresholded_w_recent |> 
-  imap(
-    \(dft,nmt){
-      month_range_temp <- ifelse(nmt == "primera","MJJA","SON")
-      dft_min <- dft |> 
-        # get min per issued date (across LTs)
-        group_by(iso3,year(issued_date)) |> 
-        slice_min(
-          order_by = mm, n= 1
-        ) 
-      dft_min |> 
-        ggplot(
-          aes(x= year(issued_date),y=mm, group = 1)
-        )+
-        geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
-        geom_line(color = "black")+
-        facet_wrap(~iso3)+
-        scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
-        labs(
-          title = glue("ECMWF SEAS {month_range_temp} Forecasts"),
-          subtitle = str_to_title(nmt),
-          caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+df_min_forecast_per_year_window |> 
+  ggplot(
+    aes(x= year(issued_date),y=mm, group = 1)
+  )+
+  geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+  geom_line(color = "black")+
+  facet_grid(rows = vars(iso3), cols = vars(window))+
+  scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+  labs(
+    title = "CADC: Primera (MJJA) & Postrera (SON) Seasonal Precipitation Forecasts",
+    subtitle = "Selected admin 1 units in CADC",
+    caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
           Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
-        ) +
-        geom_text_repel(
-          data= filter(dft_min,mm_flag),
-          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size= txt_label_size
-        )+
-        theme(
-          axis.title = element_blank(),
-          legend.position = "none"
-        )
-    }
+  ) +
+  geom_text_repel(
+    data= filter(df_min_forecast_per_year_window,mm_flag),
+    aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
+  )+
+  theme(
+    axis.title = element_blank(),
+    legend.position = "none"
   )
+
+
 ```
 
-We see that the results are still the same as previously when RP was calculated from all years on record 1981-2024
+-   let's do simple linear interpolation of empirical RPs to calculate the thresholds - i think let's keep the historical record the same as 2024 monitoring 1981-2022
+
+-   note that previously I had calculated empirical RP using the inverse of the percentile as defined by default settings in R R base `stats::quantile()`. However, now I'm using the classical empirical RP calculation to align better w/ new frameworks etc.
+
+-   results unchanged
 
 ```{r}
-p_timeseries_refined_aoi_1988_2022_base$primera
-```
+#| fig.height: 8
 
-```{r}
-p_timeseries_refined_aoi_1988_2022_base$postrera
+df_seas5_thresholds <- df_combined_thresholds |> 
+  filter(
+    forecast_source =="SEAS5"
+  )
+
+df_classified_2024_seas5_thresholds <- df_historical_aa_classified |> 
+  left_join(df_seas5_thresholds, by = c("iso3","leadtime","window")) |> 
+  mutate(
+    mm_flag = mm<=value_empirical
+  )
+
+
+df_min_2024_seas5_thresholds <- df_classified_2024_seas5_thresholds |> 
+  # get min per issued date (across LTs)
+  group_by(iso3,year(issued_date),window) |> 
+  slice_max(
+    order_by = rp_emp, n= 1,with_ties = F
+  ) |> 
+  ungroup() |> 
+  mutate(
+    window = factor(window, levels =c("primera","postrera"))
+  )
+    
+
+
+
+
+df_min_2024_seas5_thresholds |> 
+  ggplot(
+    aes(x= year(issued_date),y=mm, group = 1)
+  )+
+  geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+  geom_line(color = "black")+
+  facet_grid(rows = vars(iso3), cols = vars(window))+
+  scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+  labs(
+    title = "CADC: Primera (MJJA) & Postrera (SON) Seasonal Precipitation Forecasts",
+    subtitle = "Selected admin 1 units in CADC",
+    caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
+  ) +
+  geom_text_repel(
+    data= filter(df_min_forecast_per_year_window,mm_flag),
+    aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
+  )+
+  theme(
+    axis.title = element_blank(),
+    legend.position = "none"
+  )
+
 ```
 
 ### INSIVUMEH
 
-
 Looking at just INSIVUMEH historical activation record - again, we see again no activations in 2024.
+
 ```{r}
+#| fig.height: 8
 
-# We ran the same basic analysis for INSIVUMEH data in a separate R-script. As this required zonal stats on the raster files theselves, this was done in a separate rscript: `analysis/insivumeh_refined_aoi_zonal_stats.R` so that the intermediate outputs could be saved on blob to be pulled into this notebook for quicker/more effecient rendering.
+df_insivumeh_thresholds <- df_combined_thresholds |> 
+  filter(forecast_source == "INSIVUMEH")
 
-df_insivumeh_thresholds <- cumulus$blob_read(
-container = "projects",
-  name = "ds-aa-lac-dry-corridor/insivumeh_thresholds_aoi_chiquimula.parquet"
-)
 
-df_insivumeh_zonal <- cumulus$blob_read(
-  container = "projects",
-  name =  "ds-aa-lac-dry-corridor/insivumeh_zonal_stats_seasonal_aoi_chiquimula.parquet"
-)
+df_insivumeh_aa <- df_insivumeh_zonal |> 
+  # already done in parquet file -- but not bad to leav here
+  filter_historical_to_moments(window_col = "season") |> 
+  # rename to use same plotting code above
+  rename(
+    window = "season"
+  )
 
-df_insivumeh_zonal_min_per_year <- df_insivumeh_zonal |> 
+df_insivumeh_zonal_min_per_year <- df_insivumeh_aa |> 
   left_join(
     df_insivumeh_thresholds
   ) |> 
   mutate(
     mm_flag = value<=value_empirical,
-    season= fct_relevel(season, "primera","postrera")
+    window= fct_relevel(window, "primera","postrera")
   ) |> 
-  group_by(adm0_es,adm1_es,season,year(issued_date)) |> 
+  group_by(adm0_es,adm1_es,window,year(issued_date)) |> 
   slice_min(
     order_by = value, n= 1
   ) 
@@ -522,7 +470,7 @@ df_insivumeh_zonal_min_per_year |>
   )+
   geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
   geom_line(color = "black")+
-  facet_wrap(~season,scales="free", ncol=1)+
+  facet_wrap(~window)+
   scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
   labs(
     title = glue("Guatemala - INSIVUMEH - Forecasts"),
@@ -541,77 +489,47 @@ df_insivumeh_zonal_min_per_year |>
 
 ```
 
-
 ## Threshold Tables
 
 Let's remake threshold tables in case we want to update technical note in 2025:
+
 ```{r}
 
-df_insivumeh_thresholds <- df_insivumeh_thresholds |> 
-  mutate(
-    iso3 = "GTM",
-    forecast_source = "INSIVUMEH"
-  )
 
-df_ecmwf_thresholds <- df_rp4_by_lt |> 
-  imap(\(dft,nmt){
-    dft |> 
-      mutate(
-        season = nmt
-      )
-    
-  }) |> 
-  list_rbind() |> 
-  mutate(
-    forecast_source = "ECMWF SEAS5"
-  )
-
-
-df_seas5_insiv_thresholds <- df_ecmwf_thresholds |> 
+df_thresholds_aa <- df_combined_thresholds |> 
   filter(
-    !(iso3 == "GTM" & leadtime %in% c(1:4))
-  ) |> 
-  bind_rows(
-    df_insivumeh_thresholds 
-  ) |> 
-  filter(
-        leadtime<=3
-      )
+    # do not use SEAS5 for Guatemala -- only for leadtime 0
+      !(iso3 == "GTM" & leadtime %in% c(1:4) & forecast_source == "SEAS5"),
+      
+      # these 2 months not being moniored
+      !(issued_month_label %in% c("Feb","Sep")),
+      !(issued_month_label == "May" & window =="postrera")
+  )
+  
 
-
-df_thresholds_labelled <- df_seas5_insiv_thresholds %>% 
+df_thresholds_labelled <- df_thresholds_aa %>% 
   arrange(
-    iso3, season
+    iso3, window
   ) |> 
   # print(n=15) |> 
   mutate(
-    pub_month_int = ifelse(season == "primera",5- leadtime,9-leadtime),
+    pub_month_int = ifelse(window == "primera",5- leadtime,9-leadtime),
     pub_month_chr = month(pub_month_int, label =T, abb=T),
     pub_month_lt = paste0(pub_month_chr," (", leadtime,")"),
-    adm0_es = case_when(
-      iso3== "GTM"~"Guatemala",
-      iso3=="HND"~"Honduras",
-      iso3=="SLV"~"El Salvador",
-      iso3 == "NIC"~"Nicaragua"
-    )
   ) %>% 
   select(
     adm0_es, 
     pub_month_lt,
     threshold = value_empirical,
-    season,
+    window,
     forecast_source
-  ) |> 
-  filter(
-    !str_detect(pub_month_lt,"Sep")
-  )
-  
+  ) 
 
-ldf_thresholds_wide <- split(df_thresholds_labelled,df_thresholds_labelled$season) %>% 
+ldf_thresholds_wide <- split(df_thresholds_labelled,df_thresholds_labelled$window) %>% 
   map(\(dft){
     dft |> 
     arrange(adm0_es) %>% 
-        select(-forecast_source,-season) |> 
+        select(-forecast_source,-window) |> 
         filter(
           !str_detect(pub_month_lt, "^Feb")
         ) %>% 
@@ -695,19 +613,9 @@ ldf_thresholds_wide$postrera %>%
       columns = c("Guatemala"), 
       rows = 1:3
     )) %>% 
-  # tab_style(
-  #   style = cell_fill(color = ecmwf_color),
-  #   locations = cells_body(
-  #     columns = c("Guatemala"), 
-  #     rows = 3
-  #   )) %>% 
   tab_footnote(footnote = html(txt_footnote)) %>% 
    tab_header(title = "Postrera (SON 2024) Rainfall (mm) Monitoring Thresholds",
              subtitle = gt_legend
   )
 
-
-
 ```
-
-

--- a/analysis/05b_2025_AOI_adjustments.qmd
+++ b/analysis/05b_2025_AOI_adjustments.qmd
@@ -139,6 +139,9 @@ df_new_aoi_meta <- df_poly_meta |>
 ```{r}
 #| eval: false
 
+# the below doesn't need to be evaluated on render - as I save the outputs of this 
+# chunk to blob and load later. Nonetheless, we can keep the code in the notebook.
+
 lgdf_nic <- cumulus$download_fieldmaps_sf(iso3="nic",layer =c("nic_adm1","nic_adm0"))
 lgdf_hnd <- cumulus$download_fieldmaps_sf(iso3="hnd",layer=c("hnd_adm1","hnd_adm0"))
 lgdf_slv <- cumulus$download_fieldmaps_sf(iso3="slv",layer=c("slv_adm1","slv_adm0"))
@@ -310,8 +313,6 @@ df_historical_aa <- df_historical |>
     window_col ="window"
     )
 
-
-
 # Weighted Average of Forecast AOI ----------------------------------------
 
 df_historical_aa_adm0 <- df_historical_aa |> 
@@ -328,8 +329,6 @@ df_historical_aa_classified <- df_historical_aa_adm0 |>
     rp_threshold = 4,
     direction =-1
   ) 
-
-
 ```
 
 
@@ -350,7 +349,6 @@ df_max_rp_forecast_per_year_window <- df_historical_aa_classified |>
     window = factor(window, levels =c("primera","postrera"))
   )
     
-
 df_max_rp_forecast_per_year_window |> 
   ggplot(
     aes(x= year(issued_date),y=mm, group = 1)
@@ -366,14 +364,13 @@ df_max_rp_forecast_per_year_window |>
           Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
   ) +
   geom_text_repel(
-    data= filter(df_min_forecast_per_year_window,mm_flag),
+    data= filter(df_max_rp_forecast_per_year_window,mm_flag),
     aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
   )+
   theme(
     axis.title = element_blank(),
     legend.position = "none"
   )
-
 
 ```
 
@@ -407,9 +404,6 @@ df_max_rp_2024_seas5_thresholds <- df_classified_2024_seas5_thresholds |>
   )
     
 
-
-
-
 df_max_rp_2024_seas5_thresholds |> 
   ggplot(
     aes(x= year(issued_date),y=mm, group = 1)
@@ -425,7 +419,7 @@ df_max_rp_2024_seas5_thresholds |>
           Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
   ) +
   geom_text_repel(
-    data= filter(df_min_forecast_per_year_window,mm_flag),
+    data= filter(df_max_rp_2024_seas5_thresholds,mm_flag),
     aes(label = year(issued_date)), color = hdx_hex("tomato-hdx"), size=txt_label_size
   )+
   theme(
@@ -781,7 +775,7 @@ bind_rows(df_jrp_per_window_wide,
 
 ```{r 2025_season}
 #| eval: false
-#| echo: true
+#| echo: false
 
 # one-off quick look at the upcoming season. Don't need to render this, but can keep in here for now
 # don't have INSIVUMEH data yet, so just doing on ECMWF SEAS5

--- a/analysis/insivumeh_refined_aoi_zonal_stats.R
+++ b/analysis/insivumeh_refined_aoi_zonal_stats.R
@@ -4,6 +4,9 @@ library(sf)
 library(dplyr)
 library(exactextractr)
 library(lubridate)
+library(ggplot2)
+library(ggrepel)
+
 source("R/tar_insuvimeh.R")
 
 AOI_GTM <-  "Chiquimula"
@@ -111,10 +114,6 @@ df_rp4_by_lt <- rp_linear_funcs |>
       reframe(
         RP_empirical = 4,
         value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
-        # these values are exactly the same as already calculated in `df_lp3_rps` so this
-        # step is redundant, but will pack it in here anyways
-        # value_LP3 = map_dbl(RP_empirical,calc_lp3_rp_level),
-        # RP_LP3_calc = map_dbl(value_empirical,calc_lp3_rp)
       )
   }
   )
@@ -171,3 +170,37 @@ p_timeseries_refined_aoi_1988_2022_base <- ldf_seas5_thresholded_w_recent |>
 p_timeseries_refined_aoi_1988_2022_base$primera
 p_timeseries_refined_aoi_1988_2022_base$postrera
 
+
+df_insivumeh_thresholds_combined <- df_rp4_by_lt |> 
+  imap(\(x,nmt){
+    x |> 
+      mutate(
+        season = nmt
+      )
+  }
+  ) |> 
+  list_rbind()
+
+df_insiv_seasons <- ldf_insiv |> 
+  imap(
+    \(dft,nmt){
+      dft |> 
+        mutate(
+          season = nmt
+        )
+    }
+  ) |> 
+  list_rbind()
+  
+
+cumulus::blob_write(
+  df = df_insivumeh_thresholds_combined,
+  container = "projects",
+  name = "ds-aa-lac-dry-corridor/insivumeh_thresholds_aoi_chiquimula.parquet"
+  )
+
+cumulus::blob_write(
+  df = df_insiv_seasons,
+  container = "projects",
+  name =  "ds-aa-lac-dry-corridor/insivumeh_zonal_stats_seasonal_aoi_chiquimula.parquet"
+  )

--- a/analysis/insivumeh_refined_aoi_zonal_stats.R
+++ b/analysis/insivumeh_refined_aoi_zonal_stats.R
@@ -1,0 +1,173 @@
+library(RNetCDF)
+library(terra)
+library(sf)
+library(dplyr)
+library(exactextractr)
+library(lubridate)
+source("R/tar_insuvimeh.R")
+
+AOI_GTM <-  "Chiquimula"
+
+gdf_adm1 <- cumulus::download_fieldmaps_sf(iso = "gtm",layer = "gtm_adm1")$gtm_adm1
+
+gdf_gtm_aoi <- gdf_adm1 |> 
+  filter(
+    ADM1_ES == AOI_GTM
+  )
+
+
+gdb_insuvimeh_gtm <- file.path(
+  Sys.getenv("AA_DATA_DIR"),
+  "private",
+  "raw",
+  "lac",
+  "INSUVIMEH",
+  "Pronósticos_Precip_NextGen_Guatemala"
+)
+
+r_insivumeh <- load_insuvimeh_raster2(gdb = gdb_insuvimeh_gtm)
+r_insivumeh_unwraped <- unwrap(r_insivumeh)
+
+df_insivumeh_wide <- exact_extract(
+  x = r_insivumeh_unwraped,
+  y = gdf_gtm_aoi,
+  fun = "mean"
+) 
+
+df_insivumeh_long <- df_insivumeh_wide |> 
+  pivot_longer(everything()) %>%
+  separate(name, into = c("stat", "issued_date", "lt_chr"), sep = "\\.") %>%
+  mutate(
+    adm0_es = "Guatemala",
+    adm1_es = AOI_GTM,
+    issued_date = as_date(issued_date),
+    leadtime = parse_number(lt_chr),
+    valid_date = issued_date + months(leadtime)
+  )
+
+
+df_insivumeh_long_filtered <- df_insivumeh_long |> 
+  filter(
+    month(valid_date)%in% 5:11
+  ) |> 
+  filter(
+    month(issued_date)!=2
+  ) 
+
+
+df_primera_insiv <- cumulus::seas5_aggregate_forecast(
+    df_insivumeh_long_filtered,
+    value ="value",
+    valid_months = c(5:8),
+    by = c("adm0_es","adm1_es","issued_date")
+  )
+
+df_postrera_insiv <- cumulus::seas5_aggregate_forecast(
+    df_insivumeh_long_filtered,
+    value ="value",
+    valid_months = c(9:11),
+    by = c("adm0_es","adm1_es","issued_date")
+  )
+ldf_insiv <- list(
+  "primera"= df_primera_insiv,
+  "postrera"= df_postrera_insiv
+)
+
+
+ldf_thresholded_1981_2022 <- ldf_insiv |> 
+  map(
+    \(dft){
+      dft |> 
+        filter(
+          year(issued_date)<=2022
+        ) |> 
+        threshold_var(
+          var= "value",
+          by = c("adm0_es","adm1_es","leadtime"),
+          rp_threshold = 4,
+          direction =-1
+        ) 
+    }
+  )
+
+# now we can linearly interpolate:
+rp_linear_funcs <- ldf_thresholded_1981_2022 |> 
+  map(
+    \(dft){
+      dft |> 
+        group_by(adm0_es,adm1_es,leadtime) |> 
+        summarise(
+          calc_empirical_rp_level = list(approxfun(rp_emp, value,method = "linear", rule =2,yright =Inf)),
+          calc_empirical_rp = list(approxfun( value,rp_emp,method = "linear",rule =2))
+        )
+    }
+  )
+
+
+df_rp4_by_lt <- rp_linear_funcs |> 
+  map(\(dft){
+    dft |> 
+      group_by(adm0_es,adm1_es, leadtime) |> 
+      reframe(
+        RP_empirical = 4,
+        value_empirical = map_dbl(RP_empirical,calc_empirical_rp_level),
+        # these values are exactly the same as already calculated in `df_lp3_rps` so this
+        # step is redundant, but will pack it in here anyways
+        # value_LP3 = map_dbl(RP_empirical,calc_lp3_rp_level),
+        # RP_LP3_calc = map_dbl(value_empirical,calc_lp3_rp)
+      )
+  }
+  )
+
+
+ldf_seas5_thresholded_w_recent <-   map(
+  set_names(names(df_rp4_by_lt),names(df_rp4_by_lt)),
+  \(season_temp){
+    
+    df_thresh <- df_rp4_by_lt[[season_temp]]
+    df_historical  = ldf_insiv[[season_temp]]
+    df_historical |> 
+      left_join(df_thresh) |> 
+      mutate(
+        mm_flag = value<=value_empirical
+      )
+  })
+
+p_timeseries_refined_aoi_1988_2022_base <- ldf_seas5_thresholded_w_recent |> 
+  imap(
+    \(dft,nmt){
+      month_range_temp <- ifelse(nmt == "primera","MJJA","SON")
+      dft_min <- dft |> 
+        # get min per issued date (across LTs)
+        group_by(adm0_es,adm1_es,year(issued_date)) |> 
+        slice_min(
+          order_by = value, n= 1
+        ) 
+      dft_min |> 
+        ggplot(
+          aes(x= year(issued_date),y=value, group = 1)
+        )+
+        geom_point(aes(color = mm_flag), alpha= 0.7, size= 4)+
+        geom_line(color = "black")+
+        # facet_wrap(~iso3)+
+        scale_color_manual(values = c(hdx_hex("sapphire-hdx"),hdx_hex("tomato-hdx")))+
+        labs(
+          title = glue("Guatemala - INSIVUMEH - {month_range_temp}-Forecasts"),
+          subtitle = glue("{str_to_title(nmt)}:{AOI_GTM}"),
+          caption = "Plotting minimum rainfall at any leadtime monitoried in AA Framework
+          Analysis performed at sub-national levelbased on area-weighted average of admins of interest per country"
+        ) +
+        geom_text_repel(
+          data= filter(dft_min,mm_flag),
+          aes(label = year(issued_date)), color = hdx_hex("tomato-hdx")
+        )+
+        theme(
+          axis.title = element_blank(),
+          legend.position = "none"
+        )
+    }
+  )
+
+p_timeseries_refined_aoi_1988_2022_base$primera
+p_timeseries_refined_aoi_1988_2022_base$postrera
+

--- a/data-raw/migrate_insivumeh_data_to_new_drive.R
+++ b/data-raw/migrate_insivumeh_data_to_new_drive.R
@@ -1,0 +1,54 @@
+#' In process of revamping framework for 2025 needed to make some adjustments to file storage
+#' during the 2024 framework DEVELOPMENT I had originally stored INSIVUMEH data on old Gdrive
+#' during the 2024 framework MONITORING I had used a mix and mostly stored new incoming data on the blob.
+#' 
+#' therefore I want to get all the data in one good location before moving to the blob eventually.
+#' Therefore I've done the following:
+#' 1. Download any data that was from blob that was never put on GDRIVE to the old GDRIVE directory
+#' 2. Here I copy the data from the old GDRIVE to the new GDRIVE. I'm actually doing this as a script
+#' because I get an error when I try to copy so many files at once manualy w/ drag & drop. Therefore we just loop here
+#' 3. I did manually copy the `new_format` 2024 data from old GDRIVE to new GDRIVe
+
+
+library(tidyverse)
+
+fp_old <- file.path(
+  Sys.getenv("AA_DATA_DIR"),
+  "private",
+  "raw",
+  "lac",
+  "INSUVIMEH",
+  "Pronósticos_Precip_NextGen_Guatemala"
+)
+
+
+fp_new <- file.path(
+  Sys.getenv("AA_DATA_DIR_NEW"),
+  "private",
+  "raw",
+  "lac",
+  "INSIVUMEH",
+  "old_format"
+  )
+
+l_tmp_dir <- list.dirs(fp_old, recursive = F)
+l_tmp_dir |> 
+  map(\(tmp_dir_old){
+    # tmp_dir_old <- l_tmp_dir[2]
+    bname_dir <- basename(tmp_dir_old)
+    cat(bname_dir,"\n")
+    tmp_dir_new <- file.path(
+      fp_new,
+      bname_dir
+    )
+    dir.create(
+      tmp_dir_new
+    )
+    file.copy(
+      list.files(tmp_dir_old,full.names = T),
+      tmp_dir_new,
+      recursive = T
+    )
+    
+  })
+

--- a/src/datasources/insivumeh.R
+++ b/src/datasources/insivumeh.R
@@ -1,0 +1,210 @@
+box::use(
+  dplyr[...],
+  purrr[...],
+  glue,
+  RNetCDF,
+  ncmeta,
+  lubridate[...],
+  stringr[...],
+  AzureStor,
+  terra,
+  cumulus,
+  tidyr,
+  readr,
+  exactextractr
+  
+)
+
+#' @export
+load_ncdf_blob_insiv <- function(
+    run_date = Sys.Date(),
+    container = "global",
+    dir = "raster/raw",
+    stage = "dev"
+){
+  run_mo = month(run_date,label = TRUE, abbr = TRUE)
+  run_yr = year(run_date)
+  
+  prefix<- paste0("insivumeh_pronos_deterministic")
+  suffix<- paste0("start",run_mo,run_yr,".nc")
+  rgx <- glue$glue("^{dir}/{prefix}.*{suffix}$")
+  
+  blob_container <- cumulus$blob_containers()$global
+  
+
+  blob_contents <- AzureStor$list_blobs(container = blob_container,dir = "raster/raw")
+  blob_names <- stringr::str_subset(blob_contents$name,pattern = rgx)
+  # Check if blob_names is empty
+  if (length(blob_names) == 0) {
+    stop("No matching files found for the specified criteria. Check the run_date, container, and dir arguments.")
+  }
+  td <- tempdir()
+  
+  # Ensure the temporary directory is deleted when the function exits -- 
+  on.exit({
+    unlink(td, recursive = TRUE, force = TRUE)
+    message("Temporary directory deleted: ", td)
+  }, add = TRUE)
+  
+  blob_names |> 
+    purrr::map(
+      \(b){
+        
+        tf <- file.path(td,basename(b))
+        
+        AzureStor$download_blob(
+          container = blob_container,
+          src = b,
+          dest = tf,
+          overwrite = TRUE
+        )
+        
+      }
+    )
+  r <- load_ncdf_insivumeh(gdb = td)
+  unlink(td)
+  r
+}
+
+#' Title
+#' **NOTE** to reviewer: same as _targets function just chaned default wrap arg to F
+#' @param gdb 
+#' @param wrap 
+#'
+#' @return
+#' @export
+#'
+#' @examples
+load_ncdf_insivumeh <- function(gdb,wrap=F) {
+  fps <- list.files(gdb,
+                    full.names = T,
+                    recursive = T,
+                    pattern = "\\d{4}.nc$"
+  )
+  
+  lr <- fps |> 
+    map(\(fp_nc){
+      # meta data collection  - to write band_name as "{pub_date}.lt_{leadtime}"
+      valid_time_meta <- ncmeta$nc_att(fp_nc, "T", "units")$value$units
+      start_time_meta <- ncmeta$nc_att(fp_nc, "S", "units")$value$units
+      valid_date <- as_date(str_extract(valid_time_meta, "\\d{4}-\\d{2}-\\d{2}"))
+      start_date <- as_date(str_extract(start_time_meta, "\\d{4}-\\d{2}-\\d{2}"))
+      lead_time_diff <- interval(start_date, valid_date)
+      lt <- lead_time_diff %/% months(1)
+      bname <- paste0(start_date, ".lt_", lt)
+      
+      # Now we open the each file and turn it into a terra::rast()
+      cat(bname, "\n")
+      dat <- RNetCDF$open.nc(fp_nc)
+      dat_extent <- r_extent(nc_ob= dat)
+      value_array <-  RNetCDF$var.get.nc(dat, "deterministic")
+      value_array_fixed <- aperm(value_array, c(2, 1))
+      
+      rtmp <- terra$rast(
+        x = value_array_fixed,
+        ext = dat_extent,
+        crs = "OGC:CRS84"
+      )
+      # set correct band nanme
+      rtmp %>%
+        terra$set.names(bname)
+      return(rtmp)
+    })
+  # merge multi-band
+  r <- terra$rast(lr)
+  
+  # wrap so it can be saved as a target - in monitoring we won't want it wrapped
+  if(wrap){
+    r <- terra$wrap(r)  
+  }
+  return(r)
+}
+
+
+
+#' Title
+#'
+#' @param nc_ob 
+#'
+#' @return
+#'
+#' @examples
+#' nc_ck<- RNetCDF::open.nc(fps[1])
+#' r_extent(nc_ck  )
+
+r_extent <- function(nc_ob){
+  lat <- RNetCDF$var.get.nc(nc_ob, "Y")
+  lon <- RNetCDF$var.get.nc(nc_ob, "X")
+  dx <- diff(lon[1:2])
+  dy <- abs(diff(lat[1:2]))
+  ex <- c(min(lon) - dx/2, max(lon) + dx/2,
+          min(lat) - dy/2, max(lat) + dy/2)
+  return(ex)
+}
+
+#' zonal_gtm_insuvimeh
+#' @description
+#' custom targets function to run zonal means by leadtime and publication date for forecast provided by insivumeh
+#'
+#' @param r `packedSpatRaster` terra object created in pipeline
+#' @param gdf sf class polygon to run zonal statistics to
+#' @param rm_dup_years `logical` just parameter used in beginning when catalogue had issues
+#'
+#' @return `data.frame` in long format w/ zonal means by publication date and leadtime
+#' @export
+zonal_insivumeh <- function(r, zone) {
+  
+  exactextractr$exact_extract(
+    x = r,
+    y = zone,
+    fun = "mean"
+  ) %>%
+    tidyr$pivot_longer(everything()) %>%
+    tidyr$separate(name, into = c("stat", "issued_date", "lt_chr"), sep = "\\.") %>%
+    mutate(
+      adm0_es = "Guatemala",
+      issued_date = as_date(issued_date),
+      leadtime = readr$parse_number(lt_chr),
+      valid_date = issued_date + months(leadtime)
+    ) |> 
+    filter(
+      month(valid_date)%in% 5:11
+    ) |> 
+    filter(
+      month(issued_date)!=2
+    ) 
+  
+    
+}
+
+
+#' @export
+insivumeh_availability <- function(run_date){
+  # INSIVUMEH Forecast currenlty stored in global container on dev
+  # when I set it up i thought we were goign to put all rasters in one location
+  # and use STAC for cataloguing
+  blob_container <- cumulus$blob_containers()$global 
+  DIR_CURRENT_INSIV <- paste0("start",month(run_date,abbr = T,label = T))
+  blob_name_rgx <- paste0("start",format(run_date,"%b%Y"),".nc$")
+  
+  
+  container_contents <- AzureStor$list_blobs(
+    blob_container, 
+    dir = "raster/raw"
+  )
+  fps_blob <- str_subset(container_contents$name,blob_name_rgx)
+  cat("checking global/raster/raw for 6 new forecast files\n")
+  filenames_unique <-  unique(fps_blob)
+  num_unique_files <- length(fps_blob)
+  
+  ret_lgl <- num_unique_files==6
+  if(ret_lgl){
+    cat("6 unique INSIVUMEH files found for current run month")
+  }else{
+    cat("6 unique INSIVUMEH files NOT FOUND for current month")
+  }
+  ret_lgl
+}
+
+
+

--- a/src/utils/gen_utils.R
+++ b/src/utils/gen_utils.R
@@ -1,0 +1,78 @@
+box::use(
+  dplyr[...],
+  rlang[...],
+  glue[...],
+  tibble[...]
+)
+
+
+#' RP based thresholding/classifications
+#'
+#' @param df 
+#' @param var 
+#' @param by 
+#' @param rp_threshold 
+#' @param direction 
+#'
+#' @returns
+#' @export
+threshold_var <-  function(df,var, by,rp_threshold,direction=1){
+  if(direction==1){
+    ret <- df |> 
+      group_by(
+        across({{by}})
+      ) |> 
+      arrange(
+        desc(!!sym(var))
+      ) |> 
+      mutate(
+        rank = row_number(),
+        q_rank = rank/(max(rank)+1),
+        rp_emp = 1/q_rank,
+        !!sym(glue("{var}_flag")):= rp_emp>=rp_threshold
+      ) |> 
+      select(
+        -rank,
+        -q_rank
+      )
+  }
+  if(direction == -1){
+    ret <- df |> 
+      group_by(
+        across({{by}})
+      ) |> 
+      arrange(
+        (!!sym(var))
+      ) |> 
+      mutate(
+        rank = row_number(),
+        q_rank = rank/(max(rank)+1),
+        rp_emp = 1/q_rank,
+        !!sym(glue("{var}_flag")):= rp_emp>=rp_threshold
+      ) |> 
+      select(
+        -rank,
+        -q_rank
+      )
+  }
+  ret
+}
+
+#' @export
+load_aoi_df <- function(version = "2025_v1"){
+  version <- arg_match(version)
+  if(version=="2025_v1"){
+    ret <- tribble(
+      ~pcode, ~iso3,               ~name,
+      "GT20", "GTM",        "Chiquimula",
+      "HN07", "HND",        "El Paraiso",
+      "HN08", "HND", "Francisco Morazan",
+      "NI20", "NIC",            "Madriz",
+      "NI25", "NIC",            "Estelí",
+      "NI05", "NIC",     "Nueva Segovia",
+      "NI40", "NIC",         "Matagalpa",
+      "SV11", "SLV",       "San Vicente"
+    )  
+  }
+  ret
+}


### PR DESCRIPTION
Evaluation of refined AOI and it's impact on historical analyses and RP calcs. 

PR does a couple things in terms of restructuring for 2025 trigger monitoring and potential changes:

- files/functions to be sourced moved to `src` -- new folders for `utils` and `datasources` there.
- analysis file created to make a new thresholds table and save as parquet in project blob: analysis `analysis/05a_create_thresholds_geographically_refined_2025.R`
- Notebook analysis which uses those thresholds to run a historical analysis based on new thresholds and see how 2024 _would have preformed_. The Rendered_ analysis from `analysis/05b_2025_AOI_adjustments.qmd` can be viewed [here](https://rpubs.com/zackarno/cadc_2025_threshold_refinement)

I think i'l go ahead and set up one version of the monitoring assuming we will be using the new AOI. If not the case, will need to adjust and do some custom zonal stats