### PR TITLE
Tweaks for August 2025 run

### DIFF
--- a/analysis/05b_2025_AOI_adjustments.qmd
+++ b/analysis/05b_2025_AOI_adjustments.qmd
@@ -627,7 +627,6 @@ ldf_thresholds_wide$primera %>%
   )
 ```
 
-
 ```{r}
 
 # with Nicaragua

--- a/src/monitoring_2025/update_activation_status.R
+++ b/src/monitoring_2025/update_activation_status.R
@@ -44,7 +44,11 @@ box::use(
   ../utils/map
 )
 
-forecast_model_yyyymm <- "202506"
+# this parameter only effects guatemala thresholds from insivumeh. 
+# I wrote different parquet files depending on which insivumeh run to use 
+# for calculating insivumeh thresholds, but the original ECMWF thresholds
+# for other countries never change.
+forecast_model_yyyymm <- "202506" 
 WHEN_TO_MONITOR_LOCAL_DEFAULT <- c("last_primera",
                                    "last_postrera",
                                    "june_2025",

--- a/src/monitoring_2025/update_activation_status_aug2025.R
+++ b/src/monitoring_2025/update_activation_status_aug2025.R
@@ -1,0 +1,393 @@
+#' **NOTE on August 2025:** Given that it is the last activation moment of the 
+#' framework and there it's a new case where we have an activation in previous 
+#' month, I just copied this script from 
+#' `src/monitoring_2025/update_activation_status.R` and am doing
+#' updates/patching in this script to give make our email clearer. By splitting
+#' the script we also maintain clarity on exactly what was run, when, and in
+#' what state. This seems easier than creating a generalized automation process
+#' to handle this more elegantly, especially considering it's the last run
+
+#' Monitoring of SEAS5 & INSIVUMEH forecasts fore CADC AA Framework monitoring
+#' In the 2025 framework we go from a national to a sub-national monitoring.
+#' 
+#' Key points to understand the script
+#' 
+#' 1. The thresholds parquet parquet serves two purposes: 
+#'    a. provides the thresholds at each activation moment
+#'    b. is a type of config file which automatically tells the rest of the 
+#'       code which forecast source to use (SEAS5 and or INSIVUMEH)
+#' 2. Raster stats for INSIVUMEH data (when applicable) are done on the fly
+#'   as part of this code. Therefore they are run on country level dissolved
+#'   polygon. The SEAS5 data comes from admin 1 level postgres zonal stats. 
+#'   Therefore, the SEAS5 postgres/tabular data gets aggregated through a 
+#'   weighted mean (using `n_upsampled_pixels`) from the "polygon' table in 
+#'   postgres
+
+box::use(
+  dplyr[...],
+  forcats[...],
+  glue[...],
+  purrr[...],
+  readr,
+  stringr,
+  tidyr,
+  cumulus,
+  lubridate,
+  logger,
+  sf,
+  gt,
+  gghdx,
+  ggplot2[...],
+  gghdx,
+  blastula[...],
+  geoarrow[...],
+  
+)
+
+gghdx$gghdx()
+
+box::use(
+  utils = ../utils/gen_utils,
+  eu=../utils/email_utils,
+  ../datasources/insivumeh,
+  ../utils/map
+)
+
+# this parameter only effects Guatemala thresholds from INSIVUMEH. 
+# I wrote different parquet files depending on which INSIVUMEH run to use 
+# for calculating INSIVUMEH thresholds, but the original ECMWF thresholds
+# for other countries never change.
+forecast_model_yyyymm <- "202506" 
+WHEN_TO_MONITOR_LOCAL_DEFAULT <- c("last_primera",
+                                   "last_postrera",
+                                   "june_2025",
+                                   "current")[4]
+EMAIL_WHO_LOCAL_DEFAULT <- c("core_developer","developers","internal_chd","full_list")[4]
+
+
+logger$log_info(paste0("EMAIL_WHO = ", Sys.getenv("EMAIL_WHO")))
+logger$log_info(paste0("WHEN_TO_MONITOR = ", Sys.getenv("WHEN_TO_MONITOR")))
+
+EMAIL_LIST <- Sys.getenv("EMAIL_WHO", unset = EMAIL_WHO_LOCAL_DEFAULT)
+
+monitoring_when <-   Sys.getenv("WHEN_TO_MONITOR", unset = WHEN_TO_MONITOR_LOCAL_DEFAULT)
+run_date_set <- case_when(
+  monitoring_when == "last_primera" ~ lubridate$as_date("2024-04-05"),
+  monitoring_when == "last_postrera" ~ lubridate$as_date("2024-06-05"),
+  monitoring_when == "june_2025" ~ lubridate$as_date("2025-06-05"),
+  monitoring_when == "current" ~ Sys.Date(),
+)
+
+
+logger$log_info(paste0("EMAIL_LIST = ", EMAIL_LIST))
+logger$log_info(paste0("Run date set = ", run_date_set))
+
+
+df_email_receps <- eu$load_email_recipients(email_list = EMAIL_LIST)
+
+
+current_moment <-  lubridate$floor_date(run_date_set, "month")
+
+
+
+# this FALSE at the time of running.
+insiv_received <- insivumeh$insivumeh_availability(run_date = current_moment)
+
+# I will just hardcode it as FALSE in case we get data later to reflect
+# the run state for activation moment. Even if we had the data we would not 
+# use it since Guatemala has already activated
+insiv_received <- FALSE
+
+# Loading base data -------------------------------------------------------
+
+# this function can/should be edited to reflect changes in monitoring AOI
+df_aoi <- utils$load_aoi_df(version = "2025_v2")
+gdf_adm1 <- utils$load_adm1_sf()
+
+df_admin_name_lookup <- cumulus$blob_load_admin_lookup()
+
+# this threshold table dictates which thresholds and forecast source we use.
+df_thresholds <- utils$load_threshold_table(
+  file_name = glue("df_thresholds_seas5_insivumeh_adm1_refined_insiv_update_{forecast_model_yyyymm}.parquet"),
+  # file_name="df_thresholds_seas5_insivumeh_adm1_refined.parquet",
+  fallback_to_seas5 = FALSE
+)
+
+
+# Minor filtering/wrangling -----------------------------------------------
+
+df_relevant_thresholds <- df_thresholds |> 
+  filter(
+    issued_month_label == lubridate$month(current_moment, abbr= T, label =T)
+  )
+
+
+gdf_adm1_aoi <-  gdf_adm1 |> 
+  filter(
+    adm1_pcode %in% df_aoi$pcode
+  ) 
+
+
+gdf_aoi_country <- gdf_adm1_aoi |> 
+  group_by(adm0_es) |> 
+  summarise(do_union = T)
+
+
+# this is used for zonal stats only when needed w/ INSIVUMEH data
+gdf_aoi_gtm <- gdf_aoi_country |> 
+  filter(adm0_es == "Guatemala")
+
+
+# Loading forecasts -------------------------------------------------------
+
+logger$log_info("Getting lastest SEAS5 forecast from Postgres")
+# box::reload(insivumeh)
+# box::reload(utils)
+
+if(!insiv_received){
+  df_relevant_thresholds <- df_relevant_thresholds |> 
+    filter(
+      forecast_source != "INSIVUMEH"
+    )
+}
+
+
+df_forecast <-  utils$load_relevant_forecasts(
+  df = df_relevant_thresholds,
+  activation_moment = current_moment,
+  pcodes = df_aoi$pcode,
+  gdf_zone= gdf_aoi_gtm # this is only used for INSIVUMEH
+)
+
+
+# Assessing activation ####
+df_forecast_status <- df_forecast |> 
+  # inner_join() will only keep the INSIVUMEH when needed
+  inner_join(df_relevant_thresholds) |> 
+  mutate(
+    status_lgl = value<= value_empirical,
+    status = if_else(status_lgl, "Activation","No Activation"),
+    status = fct_expand(factor(status),"Activation","No Activation")
+  )
+df_forecast_status |> 
+  glimpse()
+
+
+# Preparing email content -------------------------------------------------
+# box::reload(eu)
+email_txt <- eu$email_text_list(
+  df = df_forecast_status,
+  run_date = run_date_set,
+  insivumeh_forecast_available = insiv_received 
+)
+
+email_txt$tbl_footnote <- "Thresholds for all countries have been calculated from historical ECMWF (1981-2022) to approximate 4 year return period drought level."
+email_txt$description_content <- "The AA framework has not triggered in Honduras or El Salvador. The total rainfall forecast over the 2025 Postrera season (September-November) is not predicted to be below the 1 in 4 year drought levels. The trigger status and thresholds are based on the latest ECMWF Seasonal forecast and historical ECMWF Seasonal forecasts for each country independently. <br><br><i>The framework was already activated previously in Guatemala based on the June 2025 forecast from INSIVUMEH.</i>"
+email_txt$subj <- "AA Central America Dry Corridor - Drought Monitoring - August Update - No New Activations (HND, SLV)"
+email_txt$data_accessed <- trimws(format(lubridate$as_date(current_moment), "%B %Y"))
+email_txt$status <- "<span style='color: #55b284ff;'>No New Activations</span>"
+
+email_txt
+logger$log_info("Making threshold table")
+gt_threshold_table <- df_forecast_status |> 
+  select(
+    adm0_es,value,value_empirical,status
+  ) |> 
+  gt$gt() |> 
+  gt$cols_label(
+    adm0_es="Country",
+    value= "Rainfall (mm)",
+    status = "Status",
+    value_empirical = "Threshold"
+  ) |> 
+  gt$fmt_number(columns= c("value","value_empirical"),decimals=0) |> 
+  gt$tab_header(
+    email_txt$gt_table_header
+  ) |> 
+  gt$tab_footnote(
+    footnote = email_txt$tbl_footnote
+  ) |> 
+  gt$tab_options(
+    table.font.size = 14,
+    heading.background.color = "#55b284ff",
+    # table.width = px(500)
+    table.width = gt$pct(80)
+  )
+
+logger$log_info("Making admin AOI table")
+gt_aoi <- gdf_adm1_aoi |> 
+  sf$st_drop_geometry() |> 
+  group_by(
+    adm0_es
+  ) |> 
+  summarise(
+    admin_1 = glue_collapse(adm1_es, sep = ", ")
+  ) |> 
+  gt$gt() |> 
+  gt$cols_label(
+    adm0_es = "Country",
+    admin_1 = "Admin 1"
+  ) |> 
+  gt$tab_header(
+    title = "Admin 1 units included in monitoring by country"
+  ) |> 
+  gt$cols_align(
+    align = "left"
+  ) |> 
+  gt$tab_options(
+    heading.background.color = "#55b284ff",
+    column_labels.background.color = "#D2F2F0",
+    table.font.size = 14,
+    table.width = gt$pct(80)
+  )
+
+
+
+
+
+gdf_adm0_status <- gdf_aoi_country |>
+  left_join(
+    df_forecast_status |> 
+      select(adm0_es,status) 
+  )
+
+logger$log_info("Loading Map layers from blob")
+l_gdf_simple <-  map$load_simplified_map_layers()
+
+# Move the row where adm0_pcode is "NI" from AOI_ADM0 to AOI_SURROUNDING
+ni_row <- l_gdf_simple$AOI_ADM0 %>%
+  filter(adm0_pcode == "NI")
+
+# Remove the row from AOI_ADM0
+l_gdf_simple$AOI_ADM0 <- l_gdf_simple$AOI_ADM0 %>%
+  filter(adm0_pcode != "NI")
+
+# Add the row to AOI_SURROUNDING
+l_gdf_simple$AOI_SURROUNDING <- bind_rows(l_gdf_simple$AOI_SURROUNDING, ni_row)
+
+
+gdf_adm0_status <- gdf_adm0_status |> 
+  mutate(
+    status = if_else(adm0_es=="Guatemala","Already activated",status),
+    status = fct_expand(status, "Already activated","No Activation","Activation"),
+    status = fct_relevel(status,"No Activation","Activation","Already activated")
+  )
+# box::reload(map)
+# ## 6d. Generate Map - Choropleth ####
+logger$log_info("Making Map")
+box::reload(map)
+m_choro <- map$trigger_status_choropleth(
+  gdf_aoi = gdf_adm0_status, # dissolved admin file
+  gdf_adm1 = l_gdf_simple$AOI_ADM1, # full country admin 1
+  gdf_adm0_surrounding = l_gdf_simple$AOI_SURROUNDING, # surrounding
+  gdf_adm0 = l_gdf_simple$AOI_ADM0, # full country admin 0,
+  insivumeh_data_available = insiv_received, # automate
+  aoi_txt_label_size = 8,
+  run_date = run_date_set
+)
+
+
+logger$log_info("make rainfall plot")
+## 6e. Generate plot ####
+p_rainfall <- df_forecast_status |> 
+  ggplot(
+    aes(x= adm0_es, y= value), 
+    width =0.2
+  )+
+  geom_point(
+    aes(
+      color=status,
+    ) ,
+    show.legend = c(color=TRUE)
+  ) +
+  scale_color_manual(
+    values = c(
+      `No Activation`="#55b284ff",
+      `Activation` ="#F2645A"
+    ),
+    drop=F
+  ) +
+  geom_hline(
+    aes(
+      yintercept= value_empirical), 
+    linetype="dashed",
+    color="tomato"
+  )+
+  scale_y_continuous(
+    limits=c(0,max(df_forecast_status$value)),
+    expand = expansion(mult = c(0,0.1))
+  )+
+  facet_wrap(
+    ~adm0_es,
+    scales = "free_x",
+    nrow = 1,ncol=4
+  )+
+  labs(
+    title = email_txt$plot_title,
+    subtitle= glue("Forecast Published: 2025 {email_txt$month_chr}") ,
+    y= "Rainfall (mm)",
+    caption = "Horizonal red dashed lines indicate trigger threshold level."
+  )+
+  theme(
+    axis.title.x = element_blank(),
+    title = element_text(size=16),
+    plot.subtitle = element_text(size=16),
+    legend.title = element_blank(),
+    legend.text = element_text(size=15),
+    axis.text.y = element_text(angle=90,size=15),
+    strip.text = element_text(size= 16),
+    axis.text.x = element_blank(),
+    plot.caption = element_text(hjust=0, size =14)
+  )
+
+
+
+
+email_rmd_fp <- "email_cadc_drought_monitoring_2025.Rmd"
+
+# Load in e-mail credentials
+email_creds <- creds_envvar(
+  user = Sys.getenv("CHD_DS_EMAIL_USERNAME"),
+  pass_envvar = "CHD_DS_EMAIL_PASSWORD",
+  host = Sys.getenv("CHD_DS_HOST"),
+  port = Sys.getenv("CHD_DS_PORT"),
+  use_ssl = TRUE
+)
+
+logger$log_info("knitting email")
+# in worse case that this won't send in next step - you can print this 
+# object and click `export` in Rstudio to get the .html which can be shred
+
+knitted_email <- render_email(
+  input = email_rmd_fp,
+  envir = parent.frame()
+)
+
+
+logger$log_info("Sending email")
+if(EMAIL_LIST == "full_list"){
+  df_email_receps |> 
+    map(\(dfet){
+      
+      smtp_send(
+        email = knitted_email,
+        from = "data.science@humdata.org",
+        to = dfet$email,
+        subject = ifelse(EMAIL_LIST!="full_list",paste0("TEST: ",email_txt$subj),email_txt$subj),
+        # subject = email_txt$subj,
+        credentials = email_creds,
+        verbose = TRUE
+      )
+    })
+}
+if(EMAIL_LIST!= "full_list"){
+  smtp_send(
+    email = knitted_email,
+    from = "data.science@humdata.org",
+    to = df_email_receps$email,
+    subject = ifelse(EMAIL_LIST!="full_list",paste0("TEST: ",email_txt$subj),email_txt$subj),
+    credentials = email_creds,
+    verbose = TRUE
+  )
+}
+

--- a/src/utils/map.R
+++ b/src/utils/map.R
@@ -37,12 +37,20 @@ trigger_status_choropleth <- function(
   
   # At leadtime 0 INSIVUMEH is used
   run_mo_eq_lt0 <- run_mo %in% c(5,9)
+
+  # Exception for August 25th, 2025 - Since Guatemala 
+  # has already activated we've changed the status to "Already activated"
+  # the code below injects "Not Available" as an empty factor level due
+  # to odd behaviour of if_else() - apparently this is intended. Therefore
+  # we can just skip this step altogether.
   
-  if(!insivumeh_data_available & !run_mo_eq_lt0){
+  aug25_exception <-  run_date == "2025-08-06"
+  
+  if(!insivumeh_data_available & !run_mo_eq_lt0 & !aug25_exception){
     gdf_aoi <- gdf_aoi |> 
       mutate(
         status = if_else(
-          adm0_es == "Guatemala",
+          adm0_es == "Guatemala" & status != "Already activated",
           as_factor("Not Available"),
           status)
         
@@ -73,9 +81,11 @@ trigger_status_choropleth <- function(
     scale_fill_manual(
       values = c(
         "Not Available" = gghdx$hdx_hex("gray-medium"),
+        "Already activated" = gghdx$hdx_hex("gray-medium"),
         
         "No Activation"= "#55b284ff",#"#00ad78ff", # gghdx$hdx_hex("mint-ultra-light"),
-        "Activation"=gghdx$hdx_hex("tomato-light")
+        "Activation"=gghdx$hdx_hex("tomato-light"),
+        "asdfa"="red"
         
       ),
       drop=FALSE


### PR DESCRIPTION
Tweaks for email clarity given Guatemala has already activated (June 2025). Don't think it needs review as tweaks are purely aesthetic.


leaving copilot summary here:


This pull request introduces an exception for Guatemala's activation status on August 25th, 2025, adjusts how activation statuses are handled in choropleth maps, and adds a new configuration parameter for forecast model runs. The changes primarily focus on improving the accuracy and clarity of status displays for specific dates and regions.

Exception handling for Guatemala activation:

* Added logic to skip the "Not Available" status assignment for Guatemala on August 25th, 2025, ensuring that the status "Already activated" is preserved for that date.

Configuration updates:

* Introduced the `forecast_model_yyyymm` parameter in `update_activation_status.R` to differentiate threshold calculations for Guatemala based on the INSIVUMEH run, while keeping ECMWF thresholds unchanged for other countries.

Visualization improvements:

* Updated the choropleth map color scale to include "Already activated" with the same color as "Not Available", and added a placeholder color for "asdfa" (likely for testing or future use).